### PR TITLE
resource_manager: extend sound card support for new targets

### DIFF
--- a/resource_manager/src/ResourceManager.cpp
+++ b/resource_manager/src/ResourceManager.cpp
@@ -1554,6 +1554,9 @@ int ResourceManager::init_audio()
                     strstr(snd_card_name, "diwali") ||
                     strstr(snd_card_name, "qcm6490") ||
                     strstr(snd_card_name, "bengal") ||
+                    strstr(snd_card_name, "QCS6490") ||
+                    strstr(snd_card_name, "LEMANS") ||
+                    strstr(snd_card_name, "MONACO") ||
                     strstr(snd_card_name, "qcs8300") ||
                     strstr(snd_card_name, "qcs9100") ||
                     strstr(snd_card_name, "monaco")) {


### PR DESCRIPTION
Update audio initialization logic to recognize additional sound card names: QCS6490, LEMANS, and MONACO. This ensures proper configuration loading for these platforms during runtime.