### PR TITLE
configure: add option to disable PAL compressed stream

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,6 @@ AM_CPPFLAGS += -DWSA_V883X_ADDR
 
 pal_sources = ${top_srcdir}/Pal.cpp \
               ${top_srcdir}/stream/src/Stream.cpp \
-              ${top_srcdir}/stream/src/StreamCompress.cpp \
               ${top_srcdir}/stream/src/StreamPCM.cpp \
               ${top_srcdir}/stream/src/StreamACDB.cpp \
               ${top_srcdir}/stream/src/StreamInCall.cpp \
@@ -122,7 +121,6 @@ pal_sources = ${top_srcdir}/Pal.cpp \
               ${top_srcdir}/session/src/SessionAlsaPcm.cpp \
               ${top_srcdir}/session/src/SessionAgm.cpp \
               ${top_srcdir}/session/src/SessionAlsaUtils.cpp \
-              ${top_srcdir}/session/src/SessionAlsaCompress.cpp \
               ${top_srcdir}/session/src/SessionAlsaVoice.cpp \
               ${top_srcdir}/session/src/SoundTriggerEngine.cpp \
               ${top_srcdir}/session/src/SoundTriggerEngineCapi.cpp \
@@ -139,12 +137,17 @@ pal_sources = ${top_srcdir}/Pal.cpp \
               ${top_srcdir}/utils/src/AudioHapticsInterface.cpp \
               ${top_srcdir}/utils/src/MetadataParser.cpp
 
+if !DISABLE_COMPRESS_STREAM
+pal_sources += ${top_srcdir}/session/src/SessionAlsaCompress.cpp \
+               ${top_srcdir}/stream/src/StreamCompress.cpp
+endif
+
 btbundle_plugin_sources = ${top_srcdir}/plugins/codecs/bt_base.c \
                           ${top_srcdir}/plugins/codecs/bt_bundle.c
 
 lib_LTLIBRARIES     = libpal.la
 libpal_la_SOURCES   = $(pal_sources)
-libpal_la_LIBADD    = @GLIB_LIBS@ -ltinyalsa -lar-osal -laudioroute -lar-spfhdrs -lexpat -ltinycompress
+libpal_la_LIBADD    = @GLIB_LIBS@ -ltinyalsa -lar-osal -laudioroute -lar-spfhdrs -lexpat
 libpal_la_CPPFLAGS := $(AM_CPPFLAGS)
 libpal_la_CPPFLAGS += -std=c++14
 libpal_la_LDFLAGS   = -shared -avoid-version
@@ -190,6 +193,14 @@ libpal_la_CPPFLAGS += -DPAL_CUTILS_SUPPORTED
 libpal_la_LIBADD += -lcutils -llog
 lib_bt_bundle_la_CFLAGS += -DPAL_CUTILS_SUPPORTED
 lib_bt_bundle_la_LIBADD += -lcutils -llog
+endif
+
+if !DISABLE_COMPRESS_STREAM
+libpal_la_LIBADD   += -ltinycompress
+endif
+
+if DISABLE_COMPRESS_STREAM
+libpal_la_CPPFLAGS += -DCOMPRESS_STREAM_DISABLED
 endif
 
 # install essential xml files under /etc

--- a/configure.ac
+++ b/configure.ac
@@ -99,5 +99,11 @@ AC_ARG_WITH([adsprpcd],
     [with_adsprpcd=no])
 AM_CONDITIONAL([COMPILE_ADSPRPCD], [test "x${with_adsprpcd}" = "xyes"])
 
+AC_ARG_WITH([disable_compress_stream],
+    AS_HELP_STRING([Disable PAL compressed stream (default is no)]),
+    [with_disable_compress_stream=$withval],
+    [with_disable_compress_stream=no])
+AM_CONDITIONAL([DISABLE_COMPRESS_STREAM], [test "x${with_disable_compress_stream}" = "xyes"])
+
 AC_CONFIG_FILES([ Makefile pal.pc ])
 AC_OUTPUT

--- a/session/src/Session.cpp
+++ b/session/src/Session.cpp
@@ -68,7 +68,9 @@
 #include "ResourceManager.h"
 #include "SessionGsl.h"
 #include "SessionAlsaPcm.h"
+#ifndef COMPRESS_STREAM_DISABLED
 #include "SessionAlsaCompress.h"
+#endif
 #include "SessionAgm.h"
 #include "SessionAlsaUtils.h"
 #include "SessionAlsaVoice.h"
@@ -122,9 +124,11 @@ Session* Session::makeSession(const std::shared_ptr<ResourceManager>& rm, const 
 
     switch (sAttr->type) {
         //create compressed if the stream type is compressed
+#ifndef COMPRESS_STREAM_DISABLED
         case PAL_STREAM_COMPRESSED:
             s =  new SessionAlsaCompress(rm);
             break;
+#endif
         case PAL_STREAM_VOICE_CALL:
             s = new SessionAlsaVoice(rm);
             break;


### PR DESCRIPTION
Introduce --with-disable-compress-stream configure flag to allow disabling PAL compressed stream. Added corresponding AM_CONDITIONAL for build-time checks.