### PR TITLE
armor: Add API compatibility checker configuration file

### DIFF
--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -1,0 +1,9 @@
+project: https://github.com/AudioReach/audioreach-pal
+
+branches:
+  qclinux1.0:
+    modes:
+      non-blocking:
+        headers:
+          - inc/PalDefs.h
+          - inc/PalApi.h


### PR DESCRIPTION
Add config.yml in the public_headers directory to define backward compatibility rules for public API headers. Configure the checker in non-blocking mode until blocking mode is supported by armor.