### PR TITLE
Armor: Switch API compatibility checker to blocking mode

### DIFF
--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -3,7 +3,7 @@ project: https://github.com/AudioReach/audioreach-pal
 branches:
   qclinux1.0:
     modes:
-      non-blocking:
+      blocking:
         headers:
           - inc/PalDefs.h
           - inc/PalApi.h


### PR DESCRIPTION
Update config.yml in public_headers to enforce backward compatibility rules for public API headers.