### PR TITLE
Update copyright headers to reflect Qualcomm Technologies, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,28 @@
-Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted (subject to the limitations in the
-disclaimer below) provided that the following conditions are met:
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause

--- a/Pal.cpp
+++ b/Pal.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/PalAudioRoute.h
+++ b/PalAudioRoute.h
@@ -26,7 +26,7 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the

--- a/PalCommon.h
+++ b/PalCommon.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_NDEBUG 0

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ To be available soon.
 
 ## License:
 
-Audioreach-pal (source files are licensed under the BSD-3-Clause-Clear. Check out the LICENSE for more details
+Audioreach-pal (source files are licensed under the BSD-3-Clause. Check out the LICENSE for more details

--- a/adsprpcd/adsprpcd.c
+++ b/adsprpcd/adsprpcd.c
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef VERIFY_PRINT_ERROR

--- a/configs/qcom/IoT/kalama/card-defs.xml
+++ b/configs/qcom/IoT/kalama/card-defs.xml
@@ -25,9 +25,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/mixer_paths_kalama_cdp.xml
+++ b/configs/qcom/IoT/kalama/mixer_paths_kalama_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/mixer_paths_kalama_cdp_wsa883x.xml
+++ b/configs/qcom/IoT/kalama/mixer_paths_kalama_cdp_wsa883x.xml
@@ -26,9 +26,9 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN     -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                              -->
 <!--                                                                                      -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license:    -->
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license::    -->
 <!--                                                                                      -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.             -->
+<!-- Copyright (c) 2022 Qualcomm Technologies, Inc. and/or its subsidiaries.             -->
 <!--                                                                                      -->
 <!-- Redistribution and use in source and binary forms, with or without                   -->
 <!-- modification, are permitted (subject to the limitations in the                       -->

--- a/configs/qcom/IoT/kalama/mixer_paths_kalama_grd.xml
+++ b/configs/qcom/IoT/kalama/mixer_paths_kalama_grd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/mixer_paths_kalama_mtp.xml
+++ b/configs/qcom/IoT/kalama/mixer_paths_kalama_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/mixer_paths_kalama_qrd.xml
+++ b/configs/qcom/IoT/kalama/mixer_paths_kalama_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/resourcemanager_kalama_cdp.xml
+++ b/configs/qcom/IoT/kalama/resourcemanager_kalama_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/resourcemanager_kalama_grd.xml
+++ b/configs/qcom/IoT/kalama/resourcemanager_kalama_grd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/resourcemanager_kalama_mtp.xml
+++ b/configs/qcom/IoT/kalama/resourcemanager_kalama_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/resourcemanager_kalama_qrd.xml
+++ b/configs/qcom/IoT/kalama/resourcemanager_kalama_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/kalama/usecaseKvManager.xml
+++ b/configs/qcom/IoT/kalama/usecaseKvManager.xml
@@ -27,10 +27,10 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp.xml
@@ -24,9 +24,9 @@
 <!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     -->
 <!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN    -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license: -->
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license:: -->
 <!--                                                                                   -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved           -->
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.           -->
 <!--                                                                                   -->
 <!-- Redistribution and use in source and binary forms, with or without                -->
 <!-- modification, are permitted (subject to the limitations in the                    -->

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_amic.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_amic.xml
@@ -24,9 +24,9 @@
 <!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     -->
 <!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN    -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license: -->
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license:: -->
 <!--                                                                                   -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved           -->
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.           -->
 <!--                                                                                   -->
 <!-- Redistribution and use in source and binary forms, with or without                -->
 <!-- modification, are permitted (subject to the limitations in the                    -->

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate.xml
@@ -49,11 +49,11 @@
 -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license:
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license::
 -->
 <!--
 -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 -->
 <!--
 -->

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate_amic.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate_amic.xml
@@ -49,11 +49,11 @@
 -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license:
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license::
 -->
 <!--
 -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 -->
 <!--
 -->

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate_wsa.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_slate_wsa.xml
@@ -49,11 +49,11 @@
 -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license:
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license::
 -->
 <!--
 -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 -->
 <!--
 -->

--- a/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_wsa.xml
+++ b/configs/qcom/IoT/monaco/resourcemanager_monaco_idp_wsa.xml
@@ -24,9 +24,9 @@
 <!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,     -->
 <!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN    -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license: -->
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license:: -->
 <!--                                                                                   -->
-<!-- Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved           -->
+<!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.           -->
 <!--                                                                                   -->
 <!-- Redistribution and use in source and binary forms, with or without                -->
 <!-- modification, are permitted (subject to the limitations in the                    -->

--- a/configs/qcom/IoT/pineapple/Hapticsconfig.xml
+++ b/configs/qcom/IoT/pineapple/Hapticsconfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.             -->
+<!-- Copyright (c) 2023 Qualcomm Technologies, Inc. and/or its subsidiaries.             -->
 <!--                                                                                      -->
 <!-- Redistribution and use in source and binary forms, with or without                   -->
 <!-- modification, are permitted (subject to the limitations in the                       -->

--- a/configs/qcom/IoT/pineapple/card-defs.xml
+++ b/configs/qcom/IoT/pineapple/card-defs.xml
@@ -25,9 +25,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/IoT/pineapple/mixer_paths_cliffs_cdp.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_cliffs_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_cliffs_mtp.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_cliffs_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/pineapple/mixer_paths_cliffs_mtp_wcd9395.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_cliffs_mtp_wcd9395.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_cliffs_qrd.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_cliffs_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_aim.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_aim.xml
@@ -26,10 +26,10 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
 *
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_cdp.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_cdp_wsa883x.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_cdp_wsa883x.xml
@@ -26,9 +26,9 @@
 <!--  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN     -->
 <!--  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                              -->
 <!--                                                                                      -->
-<!-- Changes from Qualcomm Innovation Center are provided under the following license:    -->
-<!-- Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.             -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                          -->
+<!-- Changes from Qualcomm Technologies, Inc. are provided under the following license::    -->
+<!-- Copyright (c) 2022 Qualcomm Technologies, Inc. and/or its subsidiaries.             -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                          -->
 
 <mixer>
     <!-- These are the initial mixer settings -->

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_mtp.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_qrd.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/mixer_paths_pineapple_qrd_sku2.xml
+++ b/configs/qcom/IoT/pineapple/mixer_paths_pineapple_qrd_sku2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/pineapple/resourcemanager_cliffs_cdp.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_cliffs_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_cliffs_mtp.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_cliffs_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 *
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/configs/qcom/IoT/pineapple/resourcemanager_cliffs_mtp_wcd9395.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_cliffs_mtp_wcd9395.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_cliffs_qrd.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_cliffs_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_pineapple_aim.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_pineapple_aim.xml
@@ -26,10 +26,10 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
 *
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_pineapple_cdp.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_pineapple_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_pineapple_mtp.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_pineapple_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_pineapple_qrd.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_pineapple_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/resourcemanager_pineapple_qrd_sku2.xml
+++ b/configs/qcom/IoT/pineapple/resourcemanager_pineapple_qrd_sku2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/pineapple/usecaseKvManager.xml
+++ b/configs/qcom/IoT/pineapple/usecaseKvManager.xml
@@ -27,9 +27,9 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_idp.xml
+++ b/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_idp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3.xml
+++ b/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_ia.xml
+++ b/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_ia.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vc.xml
+++ b/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vc.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vision.xml
+++ b/configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vision.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_idp.xml
+++ b/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_idp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3.xml
+++ b/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_ia.xml
+++ b/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_ia.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vc.xml
+++ b/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vc.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vision.xml
+++ b/configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vision.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcm6490/usecaseKvManager.xml
+++ b/configs/qcom/IoT/qcm6490/usecaseKvManager.xml
@@ -29,7 +29,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/IoT/qcs6490/mixer_paths_QCS6490_RB3Gen2.xml
+++ b/configs/qcom/IoT/qcs6490/mixer_paths_QCS6490_RB3Gen2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcs6490/resourcemanager_QCS6490_RB3Gen2.xml
+++ b/configs/qcom/IoT/qcs6490/resourcemanager_QCS6490_RB3Gen2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcs8300/mixer_paths_MONACO_EVK.xml
+++ b/configs/qcom/IoT/qcs8300/mixer_paths_MONACO_EVK.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcs8300/resourcemanager_MONACO_EVK.xml
+++ b/configs/qcom/IoT/qcs8300/resourcemanager_MONACO_EVK.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcs9075/mixer_paths_LEMANS_EVK.xml
+++ b/configs/qcom/IoT/qcs9075/mixer_paths_LEMANS_EVK.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcs9075/resourcemanager_LEMANS_EVK.xml
+++ b/configs/qcom/IoT/qcs9075/resourcemanager_LEMANS_EVK.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Technologies, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/qcs9100/mixer_paths_qcs9100_ridesx.xml
+++ b/configs/qcom/IoT/qcs9100/mixer_paths_qcs9100_ridesx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/qcs9100/resourcemanager_qcs9100_ridesx.xml
+++ b/configs/qcom/IoT/qcs9100/resourcemanager_qcs9100_ridesx.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/shikra/card-defs.xml
+++ b/configs/qcom/IoT/shikra/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/IoT/shikra/mcs_defs_shikra_cpu.xml
+++ b/configs/qcom/IoT/shikra/mcs_defs_shikra_cpu.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/IoT/shikra/mcs_defs_shikra_dsp.xml
+++ b/configs/qcom/IoT/shikra/mcs_defs_shikra_dsp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/IoT/shikra/mixer_paths_Shikra_CQM_EVK.xml
+++ b/configs/qcom/IoT/shikra/mixer_paths_Shikra_CQM_EVK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/shikra/mixer_paths_Shikra_CQS_EVK.xml
+++ b/configs/qcom/IoT/shikra/mixer_paths_Shikra_CQS_EVK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/shikra/mixer_paths_shikra_cpu.xml
+++ b/configs/qcom/IoT/shikra/mixer_paths_shikra_cpu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/shikra/mixer_paths_shikra_dsp.xml
+++ b/configs/qcom/IoT/shikra/mixer_paths_shikra_dsp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/IoT/shikra/plugin_manager.xml
+++ b/configs/qcom/IoT/shikra/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/IoT/shikra/resourcemanager_Shikra-CQM_EVK.xml
+++ b/configs/qcom/IoT/shikra/resourcemanager_Shikra-CQM_EVK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/shikra/resourcemanager_Shikra_CQS_EVK.xml
+++ b/configs/qcom/IoT/shikra/resourcemanager_Shikra_CQS_EVK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/shikra/resourcemanager_shikra_cpu.xml
+++ b/configs/qcom/IoT/shikra/resourcemanager_shikra_cpu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/shikra/resourcemanager_shikra_dsp.xml
+++ b/configs/qcom/IoT/shikra/resourcemanager_shikra_dsp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/IoT/shikra/usecaseKvManager.xml
+++ b/configs/qcom/IoT/shikra/usecaseKvManager.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/XR/anorak/card-defs.xml
+++ b/configs/qcom/XR/anorak/card-defs.xml
@@ -25,9 +25,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/XR/anorak/mixer_paths_anorak_idp.xml
+++ b/configs/qcom/XR/anorak/mixer_paths_anorak_idp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/XR/anorak/mixer_paths_anorak_qxr.xml
+++ b/configs/qcom/XR/anorak/mixer_paths_anorak_qxr.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/XR/anorak/resourcemanager_anorak_idp.xml
+++ b/configs/qcom/XR/anorak/resourcemanager_anorak_idp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/XR/anorak/resourcemanager_anorak_qxr.xml
+++ b/configs/qcom/XR/anorak/resourcemanager_anorak_qxr.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/XR/anorak/usecaseKvManager.xml
+++ b/configs/qcom/XR/anorak/usecaseKvManager.xml
@@ -27,9 +27,9 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/automotive/plugin_manager.xml
+++ b/configs/qcom/automotive/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/automotive/resourcemanager_VIOSND.xml
+++ b/configs/qcom/automotive/resourcemanager_VIOSND.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/automotive/usecaseKvManager-VIOSND.xml
+++ b/configs/qcom/automotive/usecaseKvManager-VIOSND.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/compute/hamoa/Hapticsconfig.xml
+++ b/configs/qcom/compute/hamoa/Hapticsconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.                        -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                               -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                               -->
 
 <haptics_param_values>
     <predefined_effect>

--- a/configs/qcom/compute/hamoa/card-defs.xml
+++ b/configs/qcom/compute/hamoa/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/compute/hamoa/mcs_defs_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa/mcs_defs_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/compute/hamoa/mixer_paths_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa/mixer_paths_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <mixer>

--- a/configs/qcom/compute/hamoa/plugin_manager.xml
+++ b/configs/qcom/compute/hamoa/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/compute/hamoa/resourcemanager_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa/resourcemanager_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/compute/hamoa/usecaseKvManager.xml
+++ b/configs/qcom/compute/hamoa/usecaseKvManager.xml
@@ -29,7 +29,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/compute/hamoa_la/Hapticsconfig.xml
+++ b/configs/qcom/compute/hamoa_la/Hapticsconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.                        -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                               -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                               -->
 
 <haptics_param_values>
     <predefined_effect>

--- a/configs/qcom/compute/hamoa_la/card-defs.xml
+++ b/configs/qcom/compute/hamoa_la/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/compute/hamoa_la/mcs_defs_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/mcs_defs_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/compute/hamoa_la/mcs_defs_hamoa_x1e80100_qcp_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/mcs_defs_hamoa_x1e80100_qcp_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/compute/hamoa_la/mixer_paths_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/mixer_paths_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <mixer>

--- a/configs/qcom/compute/hamoa_la/mixer_paths_hamoa_x1e80100_qcp_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/mixer_paths_hamoa_x1e80100_qcp_wsa884x.xml
@@ -25,7 +25,7 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 <mixer>
 <!-- Common File Contents  -->

--- a/configs/qcom/compute/hamoa_la/plugin_manager.xml
+++ b/configs/qcom/compute/hamoa_la/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/compute/hamoa_la/resourcemanager_hamoa_x1e80100_crd_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/resourcemanager_hamoa_x1e80100_crd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/compute/hamoa_la/resourcemanager_hamoa_x1e80100_qcp_wsa884x.xml
+++ b/configs/qcom/compute/hamoa_la/resourcemanager_hamoa_x1e80100_qcp_wsa884x.xml
@@ -25,7 +25,7 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 <resource_manager_info>
     <version>2.0</version>

--- a/configs/qcom/compute/hamoa_la/usecaseKvManager.xml
+++ b/configs/qcom/compute/hamoa_la/usecaseKvManager.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/mobile/art/Hapticsconfig.xml
+++ b/configs/qcom/mobile/art/Hapticsconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.                        -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                               -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                               -->
 <haptics_param_values>
     <predefined_effect>
         <!-- CLICK -->

--- a/configs/qcom/mobile/art/card-defs-native.xml
+++ b/configs/qcom/mobile/art/card-defs-native.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/mobile/art/card-defs.xml
+++ b/configs/qcom/mobile/art/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/mobile/art/mcs_defs_art_cdp.xml
+++ b/configs/qcom/mobile/art/mcs_defs_art_cdp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/art/mcs_defs_art_mtp.xml
+++ b/configs/qcom/mobile/art/mcs_defs_art_mtp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/art/mcs_defs_art_mtp_qmp.xml
+++ b/configs/qcom/mobile/art/mcs_defs_art_mtp_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/art/mcs_defs_art_qrd.xml
+++ b/configs/qcom/mobile/art/mcs_defs_art_qrd.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/art/mcs_defs_art_qrd_qmp.xml
+++ b/configs/qcom/mobile/art/mcs_defs_art_qrd_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/art/mixer_paths_art_cdp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_art_cdp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_art_mtp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_art_mtp.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_art_mtp_qmp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_art_mtp_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_art_qrd.xml
+++ b/configs/qcom/mobile/art/mixer_paths_art_qrd.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_art_qrd_qmp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_art_qrd_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_pebble_cdp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_pebble_cdp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_pebble_mtp_qmp.xml
+++ b/configs/qcom/mobile/art/mixer_paths_pebble_mtp_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_pebble_mtp_wcd9378.xml
+++ b/configs/qcom/mobile/art/mixer_paths_pebble_mtp_wcd9378.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/mixer_paths_pebble_qrd.xml
+++ b/configs/qcom/mobile/art/mixer_paths_pebble_qrd.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license::
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/art/plugin_manager.xml
+++ b/configs/qcom/mobile/art/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_art_cdp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_art_cdp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_art_mtp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_art_mtp.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_art_mtp_qmp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_art_mtp_qmp.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_art_qrd.xml
+++ b/configs/qcom/mobile/art/resourcemanager_art_qrd.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_art_qrd_qmp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_art_qrd_qmp.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_pebble_cdp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_pebble_cdp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_pebble_mtp_qmp.xml
+++ b/configs/qcom/mobile/art/resourcemanager_pebble_mtp_qmp.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_pebble_mtp_wcd9378.xml
+++ b/configs/qcom/mobile/art/resourcemanager_pebble_mtp_wcd9378.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/resourcemanager_pebble_qrd.xml
+++ b/configs/qcom/mobile/art/resourcemanager_pebble_qrd.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/art/usecaseKvManager.xml
+++ b/configs/qcom/mobile/art/usecaseKvManager.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/mobile/canoe/Hapticsconfig.xml
+++ b/configs/qcom/mobile/canoe/Hapticsconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.             -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                               -->
+<!-- Copyright (c) 2023-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.             -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                               -->
 
 <haptics_param_values>
     <predefined_effect>

--- a/configs/qcom/mobile/canoe/card-defs.xml
+++ b/configs/qcom/mobile/canoe/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/mobile/canoe/mcs_defs_canoe_cdp_wsa885xi2s.xml
+++ b/configs/qcom/mobile/canoe/mcs_defs_canoe_cdp_wsa885xi2s.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/canoe/mcs_defs_canoe_mtp.xml
+++ b/configs/qcom/mobile/canoe/mcs_defs_canoe_mtp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/canoe/mcs_defs_canoe_mtp_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/mcs_defs_canoe_mtp_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/canoe/mcs_defs_canoe_qrd.xml
+++ b/configs/qcom/mobile/canoe/mcs_defs_canoe_qrd.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/canoe/mcs_defs_canoe_qrd_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/mcs_defs_canoe_qrd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/canoe/mixer_paths_alor_cdp.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_alor_cdp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_alor_mtp_wcd9378.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_alor_mtp_wcd9378.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_alor_mtp_wcd939x.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_alor_mtp_wcd939x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_alor_qrd.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_alor_qrd.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_atp.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_atp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp_wsa884x.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp_wsa885xi2s.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_cdp_wsa885xi2s.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp_qmp.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_mtp_wsa884x.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_qrd.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_canoe_qrd_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_canoe_qrd_wsa884x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/mixer_paths_qcm6490_rb3_ia.xml
+++ b/configs/qcom/mobile/canoe/mixer_paths_qcm6490_rb3_ia.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022, 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/canoe/plugin_manager.xml
+++ b/configs/qcom/mobile/canoe/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!-- Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+<!-- Copyright (c) 2024-2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_alor_cdp.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_alor_cdp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_alor_mtp_wcd9378.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_alor_mtp_wcd9378.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_alor_mtp_wcd939x.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_alor_mtp_wcd939x.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_alor_qrd.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_alor_qrd.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_atp.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_atp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp_wsa884x.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp_wsa885xi2s.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_cdp_wsa885xi2s.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp_qmp.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp_qmp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_mtp_wsa884x.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_qrd.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_canoe_qrd_wsa884x.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_canoe_qrd_wsa884x.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/resourcemanager_qcm6490_rb3_ia.xml
+++ b/configs/qcom/mobile/canoe/resourcemanager_qcm6490_rb3_ia.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022, 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 *  -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/canoe/usecaseKvManager.xml
+++ b/configs/qcom/mobile/canoe/usecaseKvManager.xml
@@ -27,9 +27,9 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/mobile/chora/Hapticsconfig.xml
+++ b/configs/qcom/mobile/chora/Hapticsconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.                        -->
-<!-- SPDX-License-Identifier: BSD-3-Clause-Clear                                               -->
+<!-- SPDX-License-Identifier: BSD-3-Clause                                               -->
 
 <haptics_param_values>
     <predefined_effect>

--- a/configs/qcom/mobile/chora/card-defs.xml
+++ b/configs/qcom/mobile/chora/card-defs.xml
@@ -27,7 +27,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/mobile/chora/mcs_defs_chora_atp.xml
+++ b/configs/qcom/mobile/chora/mcs_defs_chora_atp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/chora/mcs_defs_chora_cdp.xml
+++ b/configs/qcom/mobile/chora/mcs_defs_chora_cdp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/chora/mcs_defs_chora_mtp.xml
+++ b/configs/qcom/mobile/chora/mcs_defs_chora_mtp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/chora/mcs_defs_chora_mtp_qmp.xml
+++ b/configs/qcom/mobile/chora/mcs_defs_chora_mtp_qmp.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/chora/mcs_defs_chora_qrd.xml
+++ b/configs/qcom/mobile/chora/mcs_defs_chora_qrd.xml
@@ -28,7 +28,7 @@
 
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mcs_defs>

--- a/configs/qcom/mobile/chora/mixer_paths_chora_atp.xml
+++ b/configs/qcom/mobile/chora/mixer_paths_chora_atp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <mixer>

--- a/configs/qcom/mobile/chora/mixer_paths_chora_cdp.xml
+++ b/configs/qcom/mobile/chora/mixer_paths_chora_cdp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <mixer>

--- a/configs/qcom/mobile/chora/mixer_paths_chora_mtp.xml
+++ b/configs/qcom/mobile/chora/mixer_paths_chora_mtp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <mixer>

--- a/configs/qcom/mobile/chora/mixer_paths_chora_mtp_qmp.xml
+++ b/configs/qcom/mobile/chora/mixer_paths_chora_mtp_qmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/chora/mixer_paths_chora_qrd.xml
+++ b/configs/qcom/mobile/chora/mixer_paths_chora_qrd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <mixer>

--- a/configs/qcom/mobile/chora/plugin_manager.xml
+++ b/configs/qcom/mobile/chora/plugin_manager.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/mobile/chora/resourcemanager_chora_atp.xml
+++ b/configs/qcom/mobile/chora/resourcemanager_chora_atp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/chora/resourcemanager_chora_cdp.xml
+++ b/configs/qcom/mobile/chora/resourcemanager_chora_cdp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/chora/resourcemanager_chora_mtp.xml
+++ b/configs/qcom/mobile/chora/resourcemanager_chora_mtp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/chora/resourcemanager_chora_mtp_qmp.xml
+++ b/configs/qcom/mobile/chora/resourcemanager_chora_mtp_qmp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/chora/resourcemanager_chora_qrd.xml
+++ b/configs/qcom/mobile/chora/resourcemanager_chora_qrd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/chora/usecaseKvManager.xml
+++ b/configs/qcom/mobile/chora/usecaseKvManager.xml
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/mobile/sun/Hapticsconfig.xml
+++ b/configs/qcom/mobile/sun/Hapticsconfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.             -->
+<!-- Copyright (c) 2023 Qualcomm Technologies, Inc. and/or its subsidiaries.             -->
 <!--                                                                                      -->
 <!-- Redistribution and use in source and binary forms, with or without                   -->
 <!-- modification, are permitted (subject to the limitations in the                       -->

--- a/configs/qcom/mobile/sun/card-defs.xml
+++ b/configs/qcom/mobile/sun/card-defs.xml
@@ -25,9 +25,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <defs>

--- a/configs/qcom/mobile/sun/mixer_paths_sun_cdp.xml
+++ b/configs/qcom/mobile/sun/mixer_paths_sun_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/sun/mixer_paths_sun_mtp.xml
+++ b/configs/qcom/mobile/sun/mixer_paths_sun_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/sun/mixer_paths_sun_mtp_wsa883x_qmp.xml
+++ b/configs/qcom/mobile/sun/mixer_paths_sun_mtp_wsa883x_qmp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/sun/mixer_paths_sun_qrd.xml
+++ b/configs/qcom/mobile/sun/mixer_paths_sun_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/sun/mixer_paths_sun_qrd_sku2.xml
+++ b/configs/qcom/mobile/sun/mixer_paths_sun_qrd_sku2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <mixer>

--- a/configs/qcom/mobile/sun/plugin_manager.xml
+++ b/configs/qcom/mobile/sun/plugin_manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!-- Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+<!-- Copyright (c) 2024 Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <plugin_manager_info>

--- a/configs/qcom/mobile/sun/resourcemanager_sun_cdp.xml
+++ b/configs/qcom/mobile/sun/resourcemanager_sun_cdp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/sun/resourcemanager_sun_mtp.xml
+++ b/configs/qcom/mobile/sun/resourcemanager_sun_mtp.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/sun/resourcemanager_sun_qrd.xml
+++ b/configs/qcom/mobile/sun/resourcemanager_sun_qrd.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/sun/resourcemanager_sun_qrd_sku2.xml
+++ b/configs/qcom/mobile/sun/resourcemanager_sun_qrd_sku2.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <resource_manager_info>

--- a/configs/qcom/mobile/sun/usecaseKvManager.xml
+++ b/configs/qcom/mobile/sun/usecaseKvManager.xml
@@ -27,9 +27,9 @@
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/configs/qcom/telematics/sa525m/card-defs.xml
+++ b/configs/qcom/telematics/sa525m/card-defs.xml
@@ -25,9 +25,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* Changes from Qualcomm Technologies, Inc. are provided under the following license::
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 <defs>
 <card>

--- a/configs/qcom/telematics/sa525m/mixer_paths.xml
+++ b/configs/qcom/telematics/sa525m/mixer_paths.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 <mixer>
     <!-- These are the initial mixer settings -->

--- a/configs/qcom/telematics/sa525m/resourcemanager.xml
+++ b/configs/qcom/telematics/sa525m/resourcemanager.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 <resource_manager_info>
     <config_params>

--- a/configs/qcom/telematics/sa525m/usecaseKvManager.xml
+++ b/configs/qcom/telematics/sa525m/usecaseKvManager.xml
@@ -26,9 +26,9 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-* Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+* SPDX-License-Identifier: BSD-3-Clause
 * -->
 
 <graph_key_value_pair_info>

--- a/context_manager/inc/ContextManager.h
+++ b/context_manager/inc/ContextManager.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef CONTEXTMANAGER_H
 #define CONTEXTMANAGER_H

--- a/context_manager/src/ContextManager.cpp
+++ b/context_manager/src/ContextManager.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <iostream>

--- a/device/A2B2Mic/inc/A2B2Mic.h
+++ b/device/A2B2Mic/inc/A2B2Mic.h
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef A2B2MIC_H

--- a/device/A2B2Mic/src/A2B2Mic.cpp
+++ b/device/A2B2Mic/src/A2B2Mic.cpp
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: A2B2Mic"

--- a/device/A2B2Speaker/inc/A2B2Speaker.h
+++ b/device/A2B2Speaker/inc/A2B2Speaker.h
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef A2B2SPEAKER_H

--- a/device/A2B2Speaker/src/A2B2Speaker.cpp
+++ b/device/A2B2Speaker/src/A2B2Speaker.cpp
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: A2B2Speaker"

--- a/device/A2BMic/inc/A2BMic.h
+++ b/device/A2BMic/inc/A2BMic.h
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef A2BMIC_H

--- a/device/A2BMic/src/A2BMic.cpp
+++ b/device/A2BMic/src/A2BMic.cpp
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: A2BMic"

--- a/device/A2BSpeaker/inc/A2BSpeaker.h
+++ b/device/A2BSpeaker/inc/A2BSpeaker.h
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef A2BSPEAKER_H

--- a/device/A2BSpeaker/src/A2BSpeaker.cpp
+++ b/device/A2BSpeaker/src/A2BSpeaker.cpp
@@ -1,6 +1,6 @@
 /*
  *Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *SPDX-License-Identifier: BSD-3-Clause-Clear
+ *SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: A2BSpeaker"

--- a/device/Bluetooth/inc/Bluetooth.h
+++ b/device/Bluetooth/inc/Bluetooth.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _BLUETOOTH_H_

--- a/device/Bluetooth/internal/BTHostAndroidWrapper.cpp
+++ b/device/Bluetooth/internal/BTHostAndroidWrapper.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #define LOG_TAG "BTHostAndroidWrapper"
 

--- a/device/Bluetooth/internal/BTHostAndroidWrapper.h
+++ b/device/Bluetooth/internal/BTHostAndroidWrapper.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/device/Bluetooth/internal/HFPProfile.cpp
+++ b/device/Bluetooth/internal/HFPProfile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #define LOG_TAG "HFPProfile"
 

--- a/device/Bluetooth/internal/HFPProfile.h
+++ b/device/Bluetooth/internal/HFPProfile.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/device/Bluetooth/src/Bluetooth.cpp
+++ b/device/Bluetooth/src/Bluetooth.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Bluetooth"

--- a/device/DisplayPort/inc/DisplayPort.h
+++ b/device/DisplayPort/inc/DisplayPort.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef DISPLAYPORT_H

--- a/device/DisplayPort/src/DisplayPort.cpp
+++ b/device/DisplayPort/src/DisplayPort.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: DisplayPort"

--- a/device/DummyDev/inc/DummyDev.h
+++ b/device/DummyDev/inc/DummyDev.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef DUMMY_DEV_H

--- a/device/DummyDev/src/DummyDev.cpp
+++ b/device/DummyDev/src/DummyDev.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: DummyDev"

--- a/device/ECRefDevice/inc/ECRefDevice.h
+++ b/device/ECRefDevice/inc/ECRefDevice.h
@@ -1,4 +1,4 @@
-/* * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved. *
+/* * Copyright (c) 2022 Qualcomm Technologies, Inc. and/or its subsidiaries. *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
  * disclaimer below) provided that the following conditions are met:
@@ -30,7 +30,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ECREFDEVICE_H

--- a/device/ECRefDevice/src/ECRefDevice.cpp
+++ b/device/ECRefDevice/src/ECRefDevice.cpp
@@ -1,4 +1,4 @@
-/* * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved. *
+/* * Copyright (c) 2022 Qualcomm Technologies, Inc. and/or its subsidiaries. *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
  * disclaimer below) provided that the following conditions are met:
@@ -30,7 +30,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: ECRefDevice"

--- a/device/ExtEC/inc/ExtEC.h
+++ b/device/ExtEC/inc/ExtEC.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef EXTEC_H

--- a/device/ExtEC/src/ExtEC.cpp
+++ b/device/ExtEC/src/ExtEC.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: ExtEC"

--- a/device/FMDevice/inc/FMDevice.h
+++ b/device/FMDevice/inc/FMDevice.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef FM_DEVICE_H

--- a/device/FMDevice/src/FMDevice.cpp
+++ b/device/FMDevice/src/FMDevice.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: FMDevice"

--- a/device/Handset/inc/Handset.h
+++ b/device/Handset/inc/Handset.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HANDSET_H

--- a/device/Handset/src/Handset.cpp
+++ b/device/Handset/src/Handset.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -61,7 +61,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Handset"

--- a/device/HandsetMic/inc/HandsetMic.h
+++ b/device/HandsetMic/inc/HandsetMic.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HANDSETMIC_H

--- a/device/HandsetMic/src/HandsetMic.cpp
+++ b/device/HandsetMic/src/HandsetMic.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HandsetMic"

--- a/device/HandsetVaMic/inc/HandsetVaMic.h
+++ b/device/HandsetVaMic/inc/HandsetVaMic.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HANDSET_VA_MIC_H

--- a/device/HandsetVaMic/src/HandsetVaMic.cpp
+++ b/device/HandsetVaMic/src/HandsetVaMic.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HandsetVaMic"

--- a/device/HapticsDev/inc/HapticsDev.h
+++ b/device/HapticsDev/inc/HapticsDev.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HapticsDev_H

--- a/device/HapticsDev/src/HapticsDev.cpp
+++ b/device/HapticsDev/src/HapticsDev.cpp
@@ -26,8 +26,8 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -60,7 +60,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HapticsDev"

--- a/device/HapticsDev/src/HapticsDevProtection.cpp
+++ b/device/HapticsDev/src/HapticsDevProtection.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the

--- a/device/Headphone/inc/Headphone.h
+++ b/device/Headphone/inc/Headphone.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HEADPHONE_H

--- a/device/Headphone/src/Headphone.cpp
+++ b/device/Headphone/src/Headphone.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Headphone"

--- a/device/HeadsetMic/inc/HeadsetMic.h
+++ b/device/HeadsetMic/inc/HeadsetMic.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HEADSETMIC_H

--- a/device/HeadsetMic/src/HeadsetMic.cpp
+++ b/device/HeadsetMic/src/HeadsetMic.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HeadsetMic"

--- a/device/HeadsetVaMic/inc/HeadsetVaMic.h
+++ b/device/HeadsetVaMic/inc/HeadsetVaMic.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HEADSET_VA_MIC_H

--- a/device/HeadsetVaMic/src/HeadsetVaMic.cpp
+++ b/device/HeadsetVaMic/src/HeadsetVaMic.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HeadsetVaMic"

--- a/device/HfpDownlink/inc/HfpDownlink.h
+++ b/device/HfpDownlink/inc/HfpDownlink.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HFP_DOWNLINK_DEVICE_H

--- a/device/HfpDownlink/src/HfpDownlink.cpp
+++ b/device/HfpDownlink/src/HfpDownlink.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HfpDownlink"

--- a/device/HfpUplink/inc/HfpUplink.h
+++ b/device/HfpUplink/inc/HfpUplink.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HFP_UPLINK_DEVICE_H

--- a/device/HfpUplink/src/HfpUplink.cpp
+++ b/device/HfpUplink/src/HfpUplink.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HfpUplink"

--- a/device/RTProxy/inc/RTProxy.h
+++ b/device/RTProxy/inc/RTProxy.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef RTPROXY_H

--- a/device/RTProxy/src/RTProxy.cpp
+++ b/device/RTProxy/src/RTProxy.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: RTProxy"

--- a/device/Speaker/inc/Speaker.h
+++ b/device/Speaker/inc/Speaker.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SPEAKER_H

--- a/device/Speaker/inc/SpeakerProtection.h
+++ b/device/Speaker/inc/SpeakerProtection.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2023, 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -61,7 +61,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SPEAKER_PROT

--- a/device/Speaker/inc/SpeakerProtectionwsa88xx.h
+++ b/device/Speaker/inc/SpeakerProtectionwsa88xx.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/device/Speaker/src/Speaker.cpp
+++ b/device/Speaker/src/Speaker.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Speaker"

--- a/device/Speaker/src/SpeakerProtection.cpp
+++ b/device/Speaker/src/SpeakerProtection.cpp
@@ -26,7 +26,7 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
@@ -61,7 +61,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerProtection"

--- a/device/Speaker/src/SpeakerProtectionwsa883x.cpp
+++ b/device/Speaker/src/SpeakerProtectionwsa883x.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerProtectionwsa883x"

--- a/device/Speaker/src/SpeakerProtectionwsa884x.cpp
+++ b/device/Speaker/src/SpeakerProtectionwsa884x.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerProtectionwsa884x"

--- a/device/Speaker/src/SpeakerProtectionwsa885x.cpp
+++ b/device/Speaker/src/SpeakerProtectionwsa885x.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerProtectionwsa885x"

--- a/device/Speaker/src/SpeakerProtectionwsa885xI2s.cpp
+++ b/device/Speaker/src/SpeakerProtectionwsa885xI2s.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerProtectionwsa885xI2s"

--- a/device/SpeakerMic/inc/SpeakerMic.h
+++ b/device/SpeakerMic/inc/SpeakerMic.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SPEAKERMIC_H

--- a/device/SpeakerMic/src/SpeakerMic.cpp
+++ b/device/SpeakerMic/src/SpeakerMic.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SpeakerMic"

--- a/device/USBAudio/inc/USBAudio.h
+++ b/device/USBAudio/inc/USBAudio.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -61,7 +61,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef USB_H

--- a/device/USBAudio/src/USBAudio.cpp
+++ b/device/USBAudio/src/USBAudio.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -61,7 +61,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: USB"

--- a/device/UltrasoundDevice/inc/UltrasoundDevice.h
+++ b/device/UltrasoundDevice/inc/UltrasoundDevice.h
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ULTRASOUNDDEVICE_H

--- a/device/UltrasoundDevice/src/UltrasoundDevice.cpp
+++ b/device/UltrasoundDevice/src/UltrasoundDevice.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: UltrasoundDevice"

--- a/device/inc/Device.h
+++ b/device/inc/Device.h
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -62,7 +62,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef DEVICE_H

--- a/device/src/Device.cpp
+++ b/device/src/Device.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Device"

--- a/inc/PalARDefs.h
+++ b/inc/PalARDefs.h
@@ -28,8 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef PAL_AR_DEFS_H

--- a/inc/PalApi.h
+++ b/inc/PalApi.h
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /** \file pal_api.h

--- a/inc/PalDefs.h
+++ b/inc/PalDefs.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /** \file pal_defs.h

--- a/inc/PalMappings.h
+++ b/inc/PalMappings.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /** \file pal_defs.h

--- a/ipc/HwBinders/interfaces/pal/1.0/types.hal
+++ b/ipc/HwBinders/interfaces/pal/1.0/types.hal
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal@1.0;

--- a/ipc/HwBinders/pal_ipc_client/src/pal_client_wrapper.cpp
+++ b/ipc/HwBinders/pal_ipc_client/src/pal_client_wrapper.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "pal_client_wrapper"

--- a/ipc/HwBinders/pal_ipc_server/inc/pal_server_wrapper.h
+++ b/ipc/HwBinders/pal_ipc_server/inc/pal_server_wrapper.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ANDROID_SYSTEM_pal_V1_0_pal_H

--- a/ipc/HwBinders/pal_ipc_server/src/pal_server_wrapper.cpp
+++ b/ipc/HwBinders/pal_ipc_server/src/pal_server_wrapper.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "pal_server_wrapper"

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/IPAL.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/IPAL.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/IPALCallback.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/IPALCallback.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/ModifierKV.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/ModifierKV.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalAudioEffect.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalAudioEffect.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalAudioFmt.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalAudioFmt.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalBufferConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalBufferConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCShmInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCShmInfo.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCShmType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCShmType.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalChannelInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalChannelInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalChannelVolKv.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalChannelVolKv.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDevice.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDevice.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDeviceId.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDeviceId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDrainType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalDrainType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMediaConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMediaConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMetadataFlags.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMetadataFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapPosition.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalMmapPosition.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamChargerState.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamChargerState.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamId.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamPayload.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamPayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadReturnData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalSessionTime.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalSessionTime.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamAttributes.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamAttributes.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamDirection.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamDirection.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamFlag.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamFlag.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalStreamType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalTimeus.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalTimeus.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalVolumeData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/PalVolumeData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/Status.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/Status.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/TimeSpec.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/1/vendor/qti/hardware/pal/TimeSpec.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/IPAL.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/IPAL.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/IPALCallback.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/IPALCallback.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/ModifierKV.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/ModifierKV.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalAudioEffect.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalAudioEffect.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalAudioFmt.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalAudioFmt.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalBufferConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalBufferConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCShmInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCShmInfo.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCShmType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCShmType.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalChannelInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalChannelInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalChannelVolKv.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalChannelVolKv.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDevice.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDevice.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDeviceId.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDeviceId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDrainType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalDrainType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMediaConfig.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMediaConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMetadataFlags.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMetadataFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapBuffer.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapPosition.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalMmapPosition.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamChargerState.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamChargerState.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamId.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamPayload.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamPayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadReturnData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalSessionTime.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalSessionTime.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamAttributes.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamAttributes.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamDirection.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamDirection.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamFlag.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamFlag.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalStreamType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalTimeus.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalTimeus.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalVolumeData.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/PalVolumeData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/Status.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/Status.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/TimeSpec.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.pal/current/vendor/qti/hardware/pal/TimeSpec.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //

--- a/ipc/aidl/aidlconverter/inc/pal/BinderStatus.h
+++ b/ipc/aidl/aidlconverter/inc/pal/BinderStatus.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/ipc/aidl/aidlconverter/inc/pal/PalAidlToLegacy.h
+++ b/ipc/aidl/aidlconverter/inc/pal/PalAidlToLegacy.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/ipc/aidl/aidlconverter/inc/pal/PalLegacyToAidl.h
+++ b/ipc/aidl/aidlconverter/inc/pal/PalLegacyToAidl.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/ipc/aidl/aidlconverter/inc/pal/SharedMemoryWrapper.h
+++ b/ipc/aidl/aidlconverter/inc/pal/SharedMemoryWrapper.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/ipc/aidl/aidlconverter/inc/pal/Utils.h
+++ b/ipc/aidl/aidlconverter/inc/pal/Utils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
 

--- a/ipc/aidl/aidlconverter/src/PalAidlToLegacy.cpp
+++ b/ipc/aidl/aidlconverter/src/PalAidlToLegacy.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalIpc::AidlToLegacy::Converter"

--- a/ipc/aidl/aidlconverter/src/PalLegacyToAidl.cpp
+++ b/ipc/aidl/aidlconverter/src/PalLegacyToAidl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalIpc::LegacyToAidl::Converter"

--- a/ipc/aidl/aidlconverter/src/SharedMemoryWrapper.cpp
+++ b/ipc/aidl/aidlconverter/src/SharedMemoryWrapper.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalSharedMemoryWrapper"

--- a/ipc/aidl/client/PalCallback.cpp
+++ b/ipc/aidl/client/PalCallback.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "PalCallback.h"
 #include <aidl/vendor/qti/hardware/pal/BnPALCallback.h>

--- a/ipc/aidl/client/PalCallback.h
+++ b/ipc/aidl/client/PalCallback.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/ipc/aidl/client/PalClientWrapper.cpp
+++ b/ipc/aidl/client/PalClientWrapper.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalClientWrapper"

--- a/ipc/aidl/palnotifierserver/PalServerNotify.cpp
+++ b/ipc/aidl/palnotifierserver/PalServerNotify.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalServerNotify"

--- a/ipc/aidl/palnotifierserver/PalServerNotify.h
+++ b/ipc/aidl/palnotifierserver/PalServerNotify.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/ipc/aidl/palnotifierserver/Service.cpp
+++ b/ipc/aidl/palnotifierserver/Service.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalIpc::Service"

--- a/ipc/aidl/server/Manifest_IPAL.xml
+++ b/ipc/aidl/server/Manifest_IPAL.xml
@@ -1,6 +1,6 @@
 <!--
-    Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
-    SPDX-License-Identifier: BSD-3-Clause-Clear
+    Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+    SPDX-License-Identifier: BSD-3-Clause
  -->
 <manifest version="1.0" type="device">
     <!-- Audio PAL service -->

--- a/ipc/aidl/server/PalServerWrapper.cpp
+++ b/ipc/aidl/server/PalServerWrapper.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalServerWrapper"

--- a/ipc/aidl/server/PalServerWrapper.h
+++ b/ipc/aidl/server/PalServerWrapper.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <aidl/vendor/qti/hardware/pal/BnPAL.h>

--- a/ipc/aidl/server/Service.cpp
+++ b/ipc/aidl/server/Service.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PalIpc::Service"

--- a/ipc/aidl/vendor/qti/hardware/pal/IPAL.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/IPAL.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/IPALCallback.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/IPALCallback.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/ModifierKV.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/ModifierKV.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalAudioEffect.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalAudioEffect.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalAudioFmt.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalAudioFmt.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalBuffer.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalBufferConfig.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalBufferConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCShmInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCShmInfo.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCShmType.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCShmType.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCallbackBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCallbackBufferInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCallbackReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalChannelInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalChannelInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalChannelVolKv.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalChannelVolKv.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalCustomPayloadInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalDevice.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalDevice.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalDeviceCustomConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalDeviceId.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalDeviceId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalDrainType.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalDrainType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalEventReadWriteDonePayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalExternAllocBuffInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMediaConfig.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMediaConfig.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMessageQueueFlagBits.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMetadataFlags.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMetadataFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMmapBuffer.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMmapBuffer.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMmapBufferFlags.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalMmapPosition.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalMmapPosition.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalParamChargerState.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalParamChargerState.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalParamId.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalParamId.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalParamPayload.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalParamPayload.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalParamPayloadShmem.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalReadReturnData.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalReadReturnData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalReadWriteDoneCommand.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalReadWriteDoneResult.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalSessionTime.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalSessionTime.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalStreamAttributes.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalStreamAttributes.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalStreamDirection.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalStreamDirection.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalStreamFlag.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalStreamFlag.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalStreamInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalStreamInfo.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalStreamType.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalStreamType.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalTimeus.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalTimeus.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalUsbDeviceAddress.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/PalVolumeData.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/PalVolumeData.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/Status.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/Status.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/ipc/aidl/vendor/qti/hardware/pal/TimeSpec.aidl
+++ b/ipc/aidl/vendor/qti/hardware/pal/TimeSpec.aidl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package vendor.qti.hardware.pal;

--- a/plugins/PluginManager/inc/PluginManager.h
+++ b/plugins/PluginManager/inc/PluginManager.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef PLUGIN_MANAGER_H

--- a/plugins/PluginManager/inc/PluginManagerIntf.h
+++ b/plugins/PluginManager/inc/PluginManagerIntf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _PLUGIN_MANAGER_INTF_H_
 #define _PLUGIN_MANAGER_INTF_H_

--- a/plugins/PluginManager/src/PluginManager.cpp
+++ b/plugins/PluginManager/src/PluginManager.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: PluginManager"

--- a/plugins/PluginManager/src/PluginManagerStatic.cpp
+++ b/plugins/PluginManager/src/PluginManagerStatic.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: PluginManager"

--- a/plugins/codecs/bt_base.c
+++ b/plugins/codecs/bt_base.c
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: bt_base"

--- a/plugins/codecs/bt_base.h
+++ b/plugins/codecs/bt_base.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/plugins/codecs/bt_ble.c
+++ b/plugins/codecs/bt_ble.c
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: bt_ble"

--- a/plugins/codecs/bt_ble.h
+++ b/plugins/codecs/bt_ble.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _BT_BLE_H_

--- a/plugins/codecs/bt_bundle.c
+++ b/plugins/codecs/bt_bundle.c
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: bt_bundle"

--- a/plugins/codecs/bt_bundle.h
+++ b/plugins/codecs/bt_bundle.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _BT_BUNDLE_H_

--- a/plugins/codecs/bt_intf.h
+++ b/plugins/codecs/bt_intf.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _BT_PLUGIN_INTF_H_

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/IoT/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/IoT/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -28,7 +28,7 @@
 *
 * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_config_utils"

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/plugins/configs/qcom/automotive/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/automotive/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/automotive/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/automotive/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -29,7 +29,7 @@
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 *
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 */
 
 

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear 
+ * SPDX-License-Identifier: BSD-3-Clause 
 */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/compute/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/compute/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/compute/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/compute/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/compute/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/compute/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *
 */
 

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/compute/hamoa/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/compute/hamoa/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *
 */
 

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/compute/hamoa_la/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/compute/hamoa_la/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *
 */
 

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/mbb/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/mbb/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *
 */
 

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/inc/ConfigSessionAlsaCompress.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_COMPRESS_H

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/src/ConfigSessionAlsaCompress.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_compress_config"

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/inc/ConfigSessionAlsaPcm.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_PCM_H

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/src/ConfigSessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: libsession_pcm_config"

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/inc/ConfigSessionAlsaVoice.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_ALSA_VOICE_H

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/src/ConfigSessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: libsession_voice_config"

--- a/plugins/configs/qcom/mobile/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionUtils/inc/ConfigSessionUtils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CONFIG_SESSION_UTILS_H

--- a/plugins/configs/qcom/mobile/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionUtils/src/ConfigSessionUtils.cpp
@@ -26,10 +26,10 @@
 * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
-* Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
 *
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 *
 */
 

--- a/plugins/vui_interface/api/vui-interface/SoundTriggerUtils.h
+++ b/plugins/vui_interface/api/vui-interface/SoundTriggerUtils.h
@@ -30,7 +30,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SOUND_TRIGGER_UTILS_H

--- a/plugins/vui_interface/api/vui-interface/VoiceUIInterface.h
+++ b/plugins/vui_interface/api/vui-interface/VoiceUIInterface.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef VOICEUI_INTERFACE_H

--- a/plugins/vui_interface/customva_intf/inc/CustomVA.h
+++ b/plugins/vui_interface/customva_intf/inc/CustomVA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CUSTOM_VA_H

--- a/plugins/vui_interface/customva_intf/src/CustomVA.cpp
+++ b/plugins/vui_interface/customva_intf/src/CustomVA.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: CustomVA"

--- a/plugins/vui_interface/hotword_intf/inc/HotwordVA.h
+++ b/plugins/vui_interface/hotword_intf/inc/HotwordVA.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef HOTWORD_H

--- a/plugins/vui_interface/hotword_intf/src/HotwordVA.cpp
+++ b/plugins/vui_interface/hotword_intf/src/HotwordVA.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: HotwordVA"

--- a/plugins/vui_interface/sva_intf/inc/SVAInterface.h
+++ b/plugins/vui_interface/sva_intf/inc/SVAInterface.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SVA_INTERFACE_H

--- a/plugins/vui_interface/sva_intf/src/SVAInterface.cpp
+++ b/plugins/vui_interface/sva_intf/src/SVAInterface.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SVAInterface"

--- a/plugins/vui_interface/utils/inc/VUIInterfaceUtils.h
+++ b/plugins/vui_interface/utils/inc/VUIInterfaceUtils.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef VOICEUI_INTERFACE_UTILS_H

--- a/plugins/vui_interface/utils/src/VUIInterfaceUtils.cpp
+++ b/plugins/vui_interface/utils/src/VUIInterfaceUtils.cpp
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <dlfcn.h>

--- a/resource_manager/inc/ResourceManager.h
+++ b/resource_manager/inc/ResourceManager.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef RESOURCE_MANAGER_H

--- a/resource_manager/src/ResourceManager.cpp
+++ b/resource_manager/src/ResourceManager.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: ResourceManager"

--- a/resource_manager/src/SndCardMonitor.cpp
+++ b/resource_manager/src/SndCardMonitor.cpp
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SndMonitor"

--- a/session/SessionAR/inc/PayloadBuilder.h
+++ b/session/SessionAR/inc/PayloadBuilder.h
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef PAYLOAD_BUILDER_H_

--- a/session/SessionAR/inc/SessionAR.h
+++ b/session/SessionAR/inc/SessionAR.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_AR_H

--- a/session/SessionAR/inc/SessionAlsaUtils.h
+++ b/session/SessionAR/inc/SessionAlsaUtils.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- *  Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- *  Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- *  SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_ALSAUTILS_H

--- a/session/SessionAR/src/PayloadBuilder.cpp
+++ b/session/SessionAR/src/PayloadBuilder.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: PayloadBuilder"

--- a/session/SessionAR/src/SessionAR.cpp
+++ b/session/SessionAR/src/SessionAR.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SessionAR"

--- a/session/SessionAR/src/SessionAlsaUtils.cpp
+++ b/session/SessionAR/src/SessionAlsaUtils.cpp
@@ -28,7 +28,7 @@
 *
 * Changes from Qualcomm Technologies, Inc. are provided under the following license:
 * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+* SPDX-License-Identifier: BSD-3-Clause
 */
 
 #define LOG_TAG "PAL: SessionAlsaUtils"

--- a/session/SessionAgm/inc/SessionAgm.h
+++ b/session/SessionAgm/inc/SessionAgm.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_AGM_H

--- a/session/SessionAgm/src/SessionAgm.cpp
+++ b/session/SessionAgm/src/SessionAgm.cpp
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SessionAgm"

--- a/session/SessionAlsaCompress/inc/SessionAlsaCompress.h
+++ b/session/SessionAlsaCompress/inc/SessionAlsaCompress.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_ALSACOMPRESS_H

--- a/session/SessionAlsaCompress/src/SessionAlsaCompress.cpp
+++ b/session/SessionAlsaCompress/src/SessionAlsaCompress.cpp
@@ -29,7 +29,7 @@
  * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SessionAlsaCompress"

--- a/session/SessionAlsaPcm/inc/SessionAlsaPcm.h
+++ b/session/SessionAlsaPcm/inc/SessionAlsaPcm.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_ALSAPCM_H

--- a/session/SessionAlsaPcm/src/SessionAlsaPcm.cpp
+++ b/session/SessionAlsaPcm/src/SessionAlsaPcm.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SessionAlsaPcm"

--- a/session/SessionAlsaVoice/inc/SessionAlsaVoice.h
+++ b/session/SessionAlsaVoice/inc/SessionAlsaVoice.h
@@ -28,9 +28,9 @@
  */
 
 /*
-Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
-Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef SESSION_ALSAVOICE_H

--- a/session/SessionAlsaVoice/src/SessionAlsaVoice.cpp
+++ b/session/SessionAlsaVoice/src/SessionAlsaVoice.cpp
@@ -30,7 +30,7 @@
 /*
 Changes from Qualcomm Technologies, Inc. are provided under the following license:
 Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
-SPDX-License-Identifier: BSD-3-Clause-Clear
+SPDX-License-Identifier: BSD-3-Clause
 */
 
 

--- a/session/inc/Session.h
+++ b/session/inc/Session.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SESSION_H

--- a/session/src/Session.cpp
+++ b/session/src/Session.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the

--- a/sounddose/inc/SoundDoseUtility.h
+++ b/sounddose/inc/SoundDoseUtility.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SOUND_DOSE_UTILITY_H

--- a/sounddose/src/SoundDoseUtility.cpp
+++ b/sounddose/src/SoundDoseUtility.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: SoundDoseUtility"

--- a/stream/StreamACD/inc/ACDEngine.h
+++ b/stream/StreamACD/inc/ACDEngine.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamACD/inc/ContextDetectionEngine.h
+++ b/stream/StreamACD/inc/ContextDetectionEngine.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2023,2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamACD/inc/StreamACD.h
+++ b/stream/StreamACD/inc/StreamACD.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamACD/src/ACDEngine.cpp
+++ b/stream/StreamACD/src/ACDEngine.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/stream/StreamACD/src/ContextDetectionEngine.cpp
+++ b/stream/StreamACD/src/ContextDetectionEngine.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: ContextDetectionEngine"

--- a/stream/StreamACD/src/StreamACD.cpp
+++ b/stream/StreamACD/src/StreamACD.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamACD"

--- a/stream/StreamASR/inc/ASREngine.h
+++ b/stream/StreamASR/inc/ASREngine.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ASRENGINE_H

--- a/stream/StreamASR/inc/StreamASR.h
+++ b/stream/StreamASR/inc/StreamASR.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMASR_H_

--- a/stream/StreamASR/src/ASREngine.cpp
+++ b/stream/StreamASR/src/ASREngine.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/stream/StreamASR/src/StreamASR.cpp
+++ b/stream/StreamASR/src/StreamASR.cpp
@@ -28,7 +28,7 @@
  *
  * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamASR"

--- a/stream/StreamCallTranslation/inc/CallTranslationNMTEngine.h
+++ b/stream/StreamCallTranslation/inc/CallTranslationNMTEngine.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef NMTENGINE_H

--- a/stream/StreamCallTranslation/inc/StreamCallTranslation.h
+++ b/stream/StreamCallTranslation/inc/StreamCallTranslation.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef StreamCallTranslation_H_

--- a/stream/StreamCallTranslation/src/CallTranslationNMTEngine.cpp
+++ b/stream/StreamCallTranslation/src/CallTranslationNMTEngine.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/stream/StreamCallTranslation/src/StreamCallTranslation.cpp
+++ b/stream/StreamCallTranslation/src/StreamCallTranslation.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "StreamCallTranslation"

--- a/stream/StreamCommon/StreamCommonProxy/inc/StreamCommonProxy.h
+++ b/stream/StreamCommon/StreamCommonProxy/inc/StreamCommonProxy.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef StreamCommonProxy_H_

--- a/stream/StreamCommon/StreamCommonProxy/src/StreamCommonProxy.cpp
+++ b/stream/StreamCommon/StreamCommonProxy/src/StreamCommonProxy.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "StreamCommonProxy"

--- a/stream/StreamCommon/StreamContextProxy/inc/StreamContextProxy.h
+++ b/stream/StreamCommon/StreamContextProxy/inc/StreamContextProxy.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMCONTEXTPROXY_H_

--- a/stream/StreamCommon/StreamContextProxy/src/StreamContextProxy.cpp
+++ b/stream/StreamCommon/StreamContextProxy/src/StreamContextProxy.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "StreamContextProxy"

--- a/stream/StreamCommon/StreamSensorPCMData/inc/StreamSensorPCMData.h
+++ b/stream/StreamCommon/StreamSensorPCMData/inc/StreamSensorPCMData.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef StreamSensorPCMData_H_

--- a/stream/StreamCommon/StreamSensorPCMData/src/StreamSensorPCMData.cpp
+++ b/stream/StreamCommon/StreamSensorPCMData/src/StreamSensorPCMData.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamSensorPCMData"

--- a/stream/StreamCommon/StreamSensorRenderer/inc/StreamSensorRenderer.h
+++ b/stream/StreamCommon/StreamSensorRenderer/inc/StreamSensorRenderer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMSENSORRENDERER_H_

--- a/stream/StreamCommon/StreamSensorRenderer/src/StreamSensorRenderer.cpp
+++ b/stream/StreamCommon/StreamSensorRenderer/src/StreamSensorRenderer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamSensorRenderer"

--- a/stream/StreamCommon/StreamUltrasSound/inc/StreamUltraSound.h
+++ b/stream/StreamCommon/StreamUltrasSound/inc/StreamUltraSound.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMULTRASOUND_H_

--- a/stream/StreamCommon/StreamUltrasSound/src/StreamUltraSound.cpp
+++ b/stream/StreamCommon/StreamUltrasSound/src/StreamUltraSound.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamUltraSound"

--- a/stream/StreamCommon/inc/StreamCommon.h
+++ b/stream/StreamCommon/inc/StreamCommon.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center, Inc. are provided under the following license:
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMCOMMON_H_

--- a/stream/StreamCommon/src/StreamCommon.cpp
+++ b/stream/StreamCommon/src/StreamCommon.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamCommon"

--- a/stream/StreamCompress/inc/StreamCompress.h
+++ b/stream/StreamCompress/inc/StreamCompress.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMCOMPRESS_H_

--- a/stream/StreamCompress/src/StreamCompress.cpp
+++ b/stream/StreamCompress/src/StreamCompress.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamCompress"

--- a/stream/StreamDummy/inc/StreamDummy.h
+++ b/stream/StreamDummy/inc/StreamDummy.h
@@ -28,7 +28,7 @@
 
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMDUMMY_H_

--- a/stream/StreamDummy/src/StreamDummy.cpp
+++ b/stream/StreamDummy/src/StreamDummy.cpp
@@ -29,7 +29,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamDummy"

--- a/stream/StreamHaptic/inc/StreamHaptics.h
+++ b/stream/StreamHaptic/inc/StreamHaptics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -34,7 +34,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMHAPTICS_H_

--- a/stream/StreamHaptic/src/StreamHaptics.cpp
+++ b/stream/StreamHaptic/src/StreamHaptics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the
@@ -34,7 +34,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamHaptics"

--- a/stream/StreamInCall/inc/StreamInCall.h
+++ b/stream/StreamInCall/inc/StreamInCall.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMINCALL_H_

--- a/stream/StreamInCall/src/StreamInCall.cpp
+++ b/stream/StreamInCall/src/StreamInCall.cpp
@@ -28,7 +28,7 @@
  *
  * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "StreamInCall"

--- a/stream/StreamNonTunnel/inc/StreamNonTunnel.h
+++ b/stream/StreamNonTunnel/inc/StreamNonTunnel.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamNonTunnel/src/StreamNonTunnel.cpp
+++ b/stream/StreamNonTunnel/src/StreamNonTunnel.cpp
@@ -28,7 +28,7 @@
  *
  * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamNonTunnel"

--- a/stream/StreamPCM/inc/StreamPCM.h
+++ b/stream/StreamPCM/inc/StreamPCM.h
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMPCM_H_

--- a/stream/StreamPCM/src/StreamPCM.cpp
+++ b/stream/StreamPCM/src/StreamPCM.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamPCM"

--- a/stream/StreamSoundTrigger/inc/PalRingBuffer.h
+++ b/stream/StreamSoundTrigger/inc/PalRingBuffer.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamSoundTrigger/inc/SoundTriggerEngine.h
+++ b/stream/StreamSoundTrigger/inc/SoundTriggerEngine.h
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamSoundTrigger/inc/SoundTriggerEngineCapi.h
+++ b/stream/StreamSoundTrigger/inc/SoundTriggerEngineCapi.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 

--- a/stream/StreamSoundTrigger/inc/SoundTriggerEngineGsl.h
+++ b/stream/StreamSoundTrigger/inc/SoundTriggerEngineGsl.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SOUNDTRIGGERENGINEGSL_H

--- a/stream/StreamSoundTrigger/inc/StreamSoundTrigger.h
+++ b/stream/StreamSoundTrigger/inc/StreamSoundTrigger.h
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAMSOUNDTRIGGER_H_

--- a/stream/StreamSoundTrigger/src/PalRingBuffer.cpp
+++ b/stream/StreamSoundTrigger/src/PalRingBuffer.cpp
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: PalRingBuffer"

--- a/stream/StreamSoundTrigger/src/SoundTriggerEngine.cpp
+++ b/stream/StreamSoundTrigger/src/SoundTriggerEngine.cpp
@@ -26,9 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the

--- a/stream/StreamSoundTrigger/src/SoundTriggerEngineCapi.cpp
+++ b/stream/StreamSoundTrigger/src/SoundTriggerEngineCapi.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef ATRACE_UNSUPPORTED
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/stream/StreamSoundTrigger/src/SoundTriggerEngineGsl.cpp
+++ b/stream/StreamSoundTrigger/src/SoundTriggerEngineGsl.cpp
@@ -29,7 +29,7 @@
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  *
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef ATRACE_UNSUPPORTED
 #define ATRACE_TAG (ATRACE_TAG_AUDIO | ATRACE_TAG_HAL)

--- a/stream/StreamSoundTrigger/src/StreamSoundTrigger.cpp
+++ b/stream/StreamSoundTrigger/src/StreamSoundTrigger.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: StreamSoundTrigger"

--- a/stream/inc/Stream.h
+++ b/stream/inc/Stream.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef STREAM_H_

--- a/stream/src/Stream.cpp
+++ b/stream/src/Stream.cpp
@@ -29,7 +29,7 @@
  * ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: Stream"

--- a/test/PalTest_main.c
+++ b/test/PalTest_main.c
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  */
 

--- a/utils/inc/ACDPlatformInfo.h
+++ b/utils/inc/ACDPlatformInfo.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ACD_PLATFORM_INFO_H

--- a/utils/inc/ASRPlatformInfo.h
+++ b/utils/inc/ASRPlatformInfo.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ASR_PLATFORM_INFO_H

--- a/utils/inc/AudioHapticsInterface.h
+++ b/utils/inc/AudioHapticsInterface.h
@@ -26,10 +26,10 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license::
  *
- * Copyright (c) 2022-2023, 2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef AUDIO_HAPTICS_INTERFACE_H

--- a/utils/inc/BTUtils.h
+++ b/utils/inc/BTUtils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef BT_UTILS_H

--- a/utils/inc/MemLogBuilder.h
+++ b/utils/inc/MemLogBuilder.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef MEMLOG_BUILDER_H

--- a/utils/inc/MetadataParser.h
+++ b/utils/inc/MetadataParser.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef METADATA_PARSER_H

--- a/utils/inc/PerfLock.h
+++ b/utils/inc/PerfLock.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #pragma once
 

--- a/utils/inc/STUtils.h
+++ b/utils/inc/STUtils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef ST_UTILS_H

--- a/utils/inc/SignalHandler.h
+++ b/utils/inc/SignalHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted (subject to the limitations in the

--- a/utils/inc/SoundTriggerPlatformInfo.h
+++ b/utils/inc/SoundTriggerPlatformInfo.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef SOUND_TRIGGER_PLATFORM_INFO_H

--- a/utils/inc/Status.h
+++ b/utils/inc/Status.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #pragma once

--- a/utils/inc/Utils.h
+++ b/utils/inc/Utils.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  **/
 
 #pragma once

--- a/utils/inc/VoiceUIPlatformInfo.h
+++ b/utils/inc/VoiceUIPlatformInfo.h
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef VOICE_UI_PLATFORM_INFO_H

--- a/utils/src/ACDPlatformInfo.cpp
+++ b/utils/src/ACDPlatformInfo.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ACDPlatformInfo.h"

--- a/utils/src/ASRPlatformInfo.cpp
+++ b/utils/src/ASRPlatformInfo.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ResourceManager.h"

--- a/utils/src/AudioHapticsInterface.cpp
+++ b/utils/src/AudioHapticsInterface.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "AudioHapticsInterface.h"

--- a/utils/src/BTUtils.cpp
+++ b/utils/src/BTUtils.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: BTUtils"

--- a/utils/src/ChargerListener.cpp
+++ b/utils/src/ChargerListener.cpp
@@ -17,9 +17,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *
-* Changes from Qualcomm Innovation Center are provided under the following
+* Changes from Qualcomm Technologies, Inc. are provided under the following
 * license:
-* Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
+* Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted (subject to the limitations in the

--- a/utils/src/MemLogBuilder.cpp
+++ b/utils/src/MemLogBuilder.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef PAL_MEMLOG_UNSUPPORTED

--- a/utils/src/MetadataParser.cpp
+++ b/utils/src/MetadataParser.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: MetadataParser"

--- a/utils/src/PerfLock.cpp
+++ b/utils/src/PerfLock.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #define NDEBUG 0
 #define LOG_TAG "PAL: PerfLock"

--- a/utils/src/STUtils.cpp
+++ b/utils/src/STUtils.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define LOG_TAG "PAL: STUtils"

--- a/utils/src/SignalHandler.cpp
+++ b/utils/src/SignalHandler.cpp
@@ -1,7 +1,7 @@
 /*
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 //#define LOG_NDEBUG 0

--- a/utils/src/SoundTriggerPlatformInfo.cpp
+++ b/utils/src/SoundTriggerPlatformInfo.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "ACDPlatformInfo.h"

--- a/utils/src/Status.cpp
+++ b/utils/src/Status.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "Status.h"
 

--- a/utils/src/VoiceUIPlatformInfo.cpp
+++ b/utils/src/VoiceUIPlatformInfo.cpp
@@ -28,7 +28,7 @@
  *
  * Changes from Qualcomm Technologies, Inc. are provided under the following license:
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
- * SPDX-License-Identifier: BSD-3-Clause-Clear
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "VoiceUIPlatformInfo.h"


### PR DESCRIPTION
- Replaced "Qualcomm Innovation Center, Inc." with "Qualcomm Technologies, Inc. and/or its subsidiaries" across multiple source files.
- Update SPDX identifier from BSD-3-Clause-Clear to BSD-3-Clause

This aligns copyright attribution with current corporate naming conventions.