### PR TITLE
CI: Switch preflight checks to pull_request

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,7 +1,7 @@
 name: Qualcomm Preflight Checks
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ qclinux1.0 ]
   push:
     branches: [ qclinux1.0 ]


### PR DESCRIPTION
Switch the preflight workflow from pull_request_target to pull_request to align with updated preflight-check orchestrator introduced in [1].

[1] AudioReach/audioreach-workflows#34