### PR TITLE
CI: Add job to filter test-ready entries from build_matrix for LAVA

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -39,10 +39,49 @@ jobs:
       build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
       pr_ref: ${{ github.event.pull_request.head.ref }}
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
-
+        
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+        
+            echo "RAW build_matrix:"
+            echo "$MATRIX"
+        
+            echo "Validating JSON..."
+            echo "$MATRIX" | jq . >/dev/null
+        
+            # Supports:
+            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
+            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
+            FILTERED=$(
+              echo "$MATRIX" | jq -c '
+                if type == "object" then
+                  to_entries
+                  | map(select(.value.testing_enabled == true))
+                  | from_entries
+                elif type == "array" then
+                  map(select(.testing_enabled == true))  # <-- Just return the array
+                else
+                  error("Unsupported build_matrix JSON type: " + (type|tostring))
+                end
+              '
+            )
+        
+            echo "Filtered matrix (pretty):"
+            echo "$FILTERED" | jq .
+        
+            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+          
   trigger_lava:
-    needs: [ load_parameters, build, process_image ]
+    needs: [ process_image, filter_test_matrix ]
     uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
     secrets: inherit
     with:
-      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
+      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}


### PR DESCRIPTION
Introduce a job to filter test-ready entries from build_matrix and route LAVA tests to the filtered result.