### PR TITLE
configs: x1e80100: set HPHR/HPHL_COMP Switch to 0

### DIFF
--- a/configs/x1e80100/mixer_paths_X1E80100_CRD.xml
+++ b/configs/x1e80100/mixer_paths_X1E80100_CRD.xml
@@ -453,8 +453,8 @@
         <ctl name="HPHR_RDAC Switch" value="1" />
         <ctl name="HPHL Switch" value="1" />
         <ctl name="HPHR Switch" value="1" />
-        <ctl name="HPHR_COMP Switch" value="1" />
-        <ctl name="HPHL_COMP Switch" value="1" />
+        <ctl name="HPHR_COMP Switch" value="0" />
+        <ctl name="HPHL_COMP Switch" value="0" />
         <ctl name="RX HPH Mode" value="CLS_H_HIFI" />
         <ctl name="RX_HPH PWR Mode" value="LOHIFI" />
         <ctl name="RX_MACRO RX0 MUX" value="AIF1_PB" />

--- a/configs/x1e80100/mixer_paths_X1E80100_EVK.xml
+++ b/configs/x1e80100/mixer_paths_X1E80100_EVK.xml
@@ -453,8 +453,8 @@
         <ctl name="HPHR_RDAC Switch" value="1" />
         <ctl name="HPHL Switch" value="1" />
         <ctl name="HPHR Switch" value="1" />
-        <ctl name="HPHR_COMP Switch" value="1" />
-        <ctl name="HPHL_COMP Switch" value="1" />
+        <ctl name="HPHR_COMP Switch" value="0" />
+        <ctl name="HPHL_COMP Switch" value="0" />
         <ctl name="RX HPH Mode" value="CLS_H_HIFI" />
         <ctl name="RX_HPH PWR Mode" value="LOHIFI" />
         <ctl name="RX_MACRO RX0 MUX" value="AIF1_PB" />


### PR DESCRIPTION
Update mixer_paths_X1E80100_{CRD,EVK}.xml to disable HPHR_COMP and HPHL_COMP Switch (value changed from 1 to 0). This aligns with the headphone enable sequence already defined in the UCM file.