### PR TITLE
Enable RPI target in pre-merge workflows

### DIFF
--- a/ci/rpi_build.sh
+++ b/ci/rpi_build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+set -ex
+echo "Running build script..."
+# Build/Compile audioreach-pal
+source ${GITHUB_WORKSPACE}/install/environment-setup-cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi
+
+# make sure we are in the right directory
+cd ${GITHUB_WORKSPACE}
+#install headers
+cd inc
+autoreconf -Wcross --verbose --install --force --exclude=autopoint
+autoconf --force
+./configure ${BUILD_ARGS}
+make DESTDIR=$SDKTARGETSYSROOT  install
+
+cd ..
+
+autoreconf -Wcross --verbose --install --force --exclude=autopoint
+autoconf --force
+
+# Run the configure script with the specified arguments
+./configure ${BUILD_ARGS} --with-glib --with-syslog
+# make
+make DESTDIR=${GITHUB_WORKSPACE}/build install


### PR DESCRIPTION
Add the rpi_build.sh script to the CI directory.