### PR TITLE
Grant workflow permissions to enable PR checks in pre-merge build

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -81,6 +81,9 @@ jobs:
 
   trigger_lava:
     needs: [ process_image, filter_test_matrix ]
+    permissions:
+      checks: write
+      pull-requests: write
     uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
     secrets: inherit
     with:


### PR DESCRIPTION
Add explicit checks and pull-requests write permissions to the trigger_lava job.