### PR TITLE
Use .la instead of .a, remove redundant XML entries and fix log format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,7 +121,7 @@ if COMPILE_COMPRESS
 libpal_la_CPPFLAGS += -DSND_COMPRESS_DEC_HDR
 endif
 libpal_la_LIBADD   += -L${abs_top_builddir}/plugins/vui_interface/.libs
-libpal_la_LIBADD   += ${abs_top_builddir}/plugins/PluginManager/.libs/libplugin_manager.a
+libpal_la_LIBADD   += ${abs_top_builddir}/plugins/PluginManager/.libs/libplugin_manager.la
 
 if CUTILS_SUPPORTED
 libpal_la_CPPFLAGS += -DPAL_CUTILS_SUPPORTED

--- a/Makefile.am
+++ b/Makefile.am
@@ -131,33 +131,13 @@ endif
 if BUILDSYSTEM_OPENWRT
 # config files for OPENWRT
 else
-libpal_la_list      = ./configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_idp.xml \
-                      ./configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_idp.xml \
-                      ./configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3.xml \
-                      ./configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3.xml \
-                      ./configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vision.xml \
-                      ./configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vision.xml \
-                      ./configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_vc.xml \
-                      ./configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_vc.xml \
-                      ./configs/qcom/IoT/qcm6490/usecaseKvManager.xml \
-                      ./configs/qcom/IoT/qcm6490/mixer_paths_qcm6490_rb3_ia.xml \
-                      ./configs/qcom/IoT/qcm6490/resourcemanager_qcm6490_rb3_ia.xml \
+libpal_la_list      = ./configs/qcom/IoT/qcm6490/usecaseKvManager.xml \
                       ./configs/qcom/IoT/qcs8300/mixer_paths_MONACO_EVK.xml \
                       ./configs/qcom/IoT/qcs8300/resourcemanager_MONACO_EVK.xml \
-                      ./configs/qcom/IoT/qcs9075/mixer_paths_qcs9075_rb8.xml \
-                      ./configs/qcom/IoT/qcs9075/resourcemanager_qcs9075_rb8.xml \
-                      ./configs/qcom/IoT/qcs9100/mixer_paths_qcs9100_ridesx.xml \
-                      ./configs/qcom/IoT/qcs9100/resourcemanager_qcs9100_ridesx.xml \
                       ./configs/qcom/IoT/qcs6490/mixer_paths_QCS6490_RB3Gen2.xml \
                       ./configs/qcom/IoT/qcs6490/resourcemanager_QCS6490_RB3Gen2.xml \
                       ./configs/qcom/IoT/qcs9075/mixer_paths_LEMANS_EVK.xml \
-                      ./configs/qcom/IoT/qcs9075/resourcemanager_LEMANS_EVK.xml
-                      ./configs/qcs9100/resourcemanager_qcs9100_ridesx.xml \
-                      ./configs/qcs6490/mixer_paths_QCS6490_RB3Gen2.xml \
-                      ./configs/qcs6490/resourcemanager_QCS6490_RB3Gen2.xml \
-                      ./configs/qcs9075/mixer_paths_LEMANS_EVK.xml \
-                      ./configs/qcs9075/resourcemanager_LEMANS_EVK.xml \
-                      ./configs/qcs9075/resourcemanager_LEMANS_EVK.xml \
+                      ./configs/qcom/IoT/qcs9075/resourcemanager_LEMANS_EVK.xml \
                       ./configs/qcom/IoT/shikra/mixer_paths_Shikra-CQM-EVK.xml \
                       ./configs/qcom/IoT/shikra/resourcemanager_Shikra-CQM-EVK.xml \
                       ./configs/qcom/IoT/shikra/mixer_paths_Shikra-CQS-EVK.xml \
@@ -170,21 +150,7 @@ root_etc_SCRIPTS = $(libpal_la_list)
 install-data-hook:
 	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_MONACO_EVK.xml
 	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_MONACO_EVK.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcs9100_ridesx.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcs9100_ridesx.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcs9075_rb8.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcs9075_rb8.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcm6490_idp.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcm6490_idp.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcm6490_rb3.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcm6490_rb3.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcm6490_rb3_vision.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcm6490_rb3_vision.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcm6490_rb3_vc.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcm6490_rb3_vc.xml
 	chmod  go+r $(DESTDIR)$(root_etcdir)/usecaseKvManager.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_qcm6490_rb3_ia.xml
-	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_qcm6490_rb3_ia.xml
 	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_QCS6490_RB3Gen2.xml
 	chmod  go+r $(DESTDIR)$(root_etcdir)/resourcemanager_QCS6490_RB3Gen2.xml
 	chmod  go+r $(DESTDIR)$(root_etcdir)/mixer_paths_LEMANS_EVK.xml

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/Makefile.am
@@ -41,7 +41,7 @@ libsession_compress_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaCompress/.libs -lsession_compress
-libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_compress_config_la_LIBADD += -lglib-2.0

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/Makefile.am
@@ -39,7 +39,7 @@ libsession_pcm_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\) 
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaPcm/.libs -lsession_pcm
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
-libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_pcm_config_la_LIBADD += -lglib-2.0

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/Makefile.am
@@ -41,7 +41,7 @@ libsession_voice_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaVoice/.libs -lsession_voice
-libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_voice_config_la_LIBADD += -lglib-2.0

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/Makefile.am
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaCompress/Makefile.am
@@ -37,7 +37,7 @@ libsession_compress_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaCompress/.libs -lsession_compress
-libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if CUTILS_SUPPORTED
 libsession_compress_config_la_CPPFLAGS += -DPAL_CUTILS_SUPPORTED

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/Makefile.am
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaPcm/Makefile.am
@@ -36,7 +36,7 @@ libsession_pcm_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\) 
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaPcm/.libs -lsession_pcm
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
-libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if CUTILS_SUPPORTED
 libsession_pcm_config_la_CPPFLAGS += -DPAL_CUTILS_SUPPORTED

--- a/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/Makefile.am
+++ b/plugins/configs/qcom/mbb/default/ConfigSessionAlsaVoice/Makefile.am
@@ -36,7 +36,7 @@ libsession_voice_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaVoice/.libs -lsession_voice
-libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mbb/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if CUTILS_SUPPORTED
 libsession_voice_config_la_CPPFLAGS += -DPAL_CUTILS_SUPPORTED

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/Makefile.am
@@ -41,7 +41,7 @@ libsession_compress_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_compress_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaCompress/.libs -lsession_compress
-libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_compress_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_compress_config_la_LIBADD += -lglib-2.0

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/Makefile.am
@@ -39,7 +39,7 @@ libsession_pcm_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\) 
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaPcm/.libs -lsession_pcm
 libsession_pcm_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
-libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_pcm_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_pcm_config_la_LIBADD += -lglib-2.0

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/Makefile.am
@@ -41,7 +41,7 @@ libsession_voice_config_la_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/.libs -lpal
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAR/.libs -lsession_ar
 libsession_voice_config_la_LIBADD   += -L${abs_top_builddir}/session/SessionAlsaVoice/.libs -lsession_voice
-libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.a
+libsession_voice_config_la_LIBADD   += ${abs_top_builddir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/.libs/libsession_utils_config.la
 
 if BUILDSYSTEM_OPENWRT
 libsession_voice_config_la_LIBADD += -lglib-2.0

--- a/resource_manager/src/ResourceManager.cpp
+++ b/resource_manager/src/ResourceManager.cpp
@@ -2705,7 +2705,7 @@ int ResourceManager::deregisterStream(Stream *s)
             if (it->second.empty())
                 activeStreamMap.erase(it);
         } else {
-            PAL_ERR(LOG_TAG, "Could not find stream to deregister", type);
+            PAL_ERR(LOG_TAG, "Could not find stream type %d to deregister", type);
             ret = -ENOENT;
         }
     } else {


### PR DESCRIPTION
Remove redundant and outdated QCS9075, QCS9100, and QCS6490 config paths from libpal_la_list in Makefile.am. This prevents duplicate installations and keeps the build config list consistent and minimal.