### PR TITLE
CI: Add pre-merge workflows, checkers, and build scripts

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -1,6 +1,6 @@
 ---
 name: pre_merge_build
-run-name: Pre Merge Build (PR:${{ github.event.pull_request.number }})
+run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre Merge Build:' }}${{ github.event.pull_request.number || github.run_number }}
 
 on:
   workflow_dispatch:
@@ -25,6 +25,7 @@ jobs:
     secrets: inherit
     with:
       build_args: ${{ needs.load_parameters.outputs.build_args }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
       event_name: ${{ github.event_name }}
       pr_ref: ${{ github.event.pull_request.head.ref }}
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
@@ -35,10 +36,55 @@ jobs:
     secrets: inherit
     with:
       event_name: ${{ github.event_name }}
+      build_matrix: ${{ needs.load_parameters.outputs.build_matrix }}
       pr_ref: ${{ github.event.pull_request.head.ref }}
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
 
+  filter_test_matrix:
+    needs: load_parameters
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.filter.outputs.test_matrix }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+
+            echo "RAW build_matrix:"
+            echo "$MATRIX"
+
+            echo "Validating JSON..."
+            echo "$MATRIX" | jq . >/dev/null
+
+            # Supports:
+            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
+            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
+            FILTERED=$(
+              echo "$MATRIX" | jq -c '
+                if type == "object" then
+                  to_entries
+                  | map(select(.value.testing_enabled == true))
+                  | from_entries
+                elif type == "array" then
+                  map(select(.testing_enabled == true))  # <-- Just return the array
+                else
+                  error("Unsupported build_matrix JSON type: " + (type|tostring))
+                end
+              '
+            )
+
+            echo "Filtered matrix (pretty):"
+            echo "$FILTERED" | jq .
+
+            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
+
   trigger_lava:
-    needs: [ load_parameters, build, process_image ]
+    needs: [ process_image, filter_test_matrix ]
+    permissions:
+      checks: write
+      pull-requests: write
     uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
     secrets: inherit
+    with:
+      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,7 +1,7 @@
 name: Qualcomm Preflight Checks
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
   push:
     branches: [ master ]

--- a/ci/knp_build.sh
+++ b/ci/knp_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 
 PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"
@@ -9,14 +9,14 @@ source "$PREBUILD_SCRIPT_PATH"
 
 
 # load build args from file if environment variable is not set
-if [ -z "${BUILD_ARGS:-}" ]; then
+if [ -z "${BUILD_ARGS}" ]; then
     BUILD_OPTIONS_FILE="${GITHUB_WORKSPACE}/ci/build_options.txt"
     BUILD_ARGS="$(sed -E 's/#.*$//' "$BUILD_OPTIONS_FILE" | sed '/^[[:space:]]*$/d' | tr '\n' ' ')"
 fi
 
 echo "Running build script..."
 # Build/Compile audioreach-pal
-source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-2a-qcom-linux
+source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-6a-qcom-linux
 
 # make sure we are in the right directory
 cd ${GITHUB_WORKSPACE}

--- a/ci/pkl_build.sh
+++ b/ci/pkl_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3-Clause-Clear
+# SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 set -ex
 
 PREBUILD_SCRIPT_PATH="${PREBUILD_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/pre_build.sh}"
@@ -9,14 +9,14 @@ source "$PREBUILD_SCRIPT_PATH"
 
 
 # load build args from file if environment variable is not set
-if [ -z "${BUILD_ARGS:-}" ]; then
+if [ -z "${BUILD_ARGS}" ]; then
     BUILD_OPTIONS_FILE="${GITHUB_WORKSPACE}/ci/build_options.txt"
     BUILD_ARGS="$(sed -E 's/#.*$//' "$BUILD_OPTIONS_FILE" | sed '/^[[:space:]]*$/d' | tr '\n' ' ')"
 fi
 
 echo "Running build script..."
 # Build/Compile audioreach-pal
-source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-2a-qcom-linux
+source ${GITHUB_WORKSPACE}/install/environment-setup-armv8-7a-qcom-linux
 
 # make sure we are in the right directory
 cd ${GITHUB_WORKSPACE}

--- a/ci/pre_build.sh
+++ b/ci/pre_build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+set -euo pipefail
+echo "Running pre-build script..."
+
+# Define target_image.json url
+url="https://raw.githubusercontent.com/AudioReach/audioreach-workflows/master/.github/actions/loading/target_image.json"
+
+# Download <sdk>.sh from aws s3 bucket and install the sdk
+if [ ! -d "${GITHUB_WORKSPACE}/install" ]; then
+    echo "SDK_NAME environment variable is not set. Fetching from JSON."
+    if curl -fsSL -o target_image.json "${url}"; then
+        SDK=$(jq -r 'to_entries[0].value.SDK_name' target_image.json)
+        if [ -n "$SDK" ] && [ "$SDK" != "null" ]; then
+            export SDK_NAME="$SDK"
+            echo "SDK_NAME set to ${SDK_NAME}"
+        else
+            echo "Error: SDK_name not found in JSON." >&2
+            exit 3
+        fi
+    else
+        echo "Failed to fetch target_image.json from $url" >&2
+        exit 1
+    fi
+    if aws s3 cp s3://qli-prd-audior-gh-artifacts/AudioReach/meta-audioreach/post_merge_build/${SDK_NAME} "${GITHUB_WORKSPACE}"; then
+        echo "SDK downloaded successfully."
+        chmod 777 "${GITHUB_WORKSPACE}/${SDK_NAME}"
+    else
+        echo "Failed to download SDK from S3. Exiting."
+        exit 1
+    fi
+    # Setup directory for sdk installation
+    mkdir -p "${GITHUB_WORKSPACE}/install"
+    orig_dir=$(pwd)
+    cd "${GITHUB_WORKSPACE}"
+    # Install the sdk
+    echo "Running SDK script..."
+    if echo "./install" | ./"${SDK_NAME}" ; then
+        echo "SDK Script ran successfully."
+    else
+        echo "Error running SDK script. Exiting."
+        exit 1
+    fi
+    cd "$orig_dir"
+else
+    echo "SDK already installed. Skipping download and installation."
+fi

--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -1,0 +1,14 @@
+project: https://github.com/AudioReach/audioreach-pal
+
+branches:
+  master:
+    modes:
+      blocking:
+        headers:
+          - inc/PalDefs.h
+          - inc/PalApi.h
+          - device/inc/Device.h
+          - session/inc/Session.h
+          - stream/inc/Stream.h
+abi_checks:
+  - path: build/usr/lib/libpal.so


### PR DESCRIPTION
Introduce checkers and pre-merge workflows using the shared
workflow from https://github.com/Audioreach/audioreach-workflows.
Update GitHub workflow configurations
(.github/workflows/pre_merge_build.yml and
.github/workflows/qcom-preflight-checks.yml) to integrate with
the centralized CI pipeline.

Add and update scripts under the ci/ directory to support build
and pre-build steps. Modify ci/build.sh and add ci/pre_build.sh,
ci/knp_build.sh, and ci/pkl_build.sh. These scripts enable SDK
setup, platform-specific builds, and reusable build logic
outside the workflow definition.

Add public_headers/config.yml to define API compatibility
checker configuration for public headers and support backward
compatibility validation as part of CI.
