### PR TITLE
PAL: restore exit log in pal_stream_close

### DIFF
--- a/Pal.cpp
+++ b/Pal.cpp
@@ -395,6 +395,7 @@ exit:
         rm->setCRSCallEnabled(false);
     rm->eraseStreamUserCounter(s);
     status = Stream::destroy(s);
+    PAL_INFO(LOG_TAG, "Exit. status %d", status);
 #ifndef PAL_MEMLOG_UNSUPPORTED
     kpiEnqueue(__func__, false);
 #endif


### PR DESCRIPTION
The PAL_INFO exit log "Exit. status %d" was inadvertently dropped from pal_stream_close() in commit b7ef47eb ("PAL: moving derived stream components to their own lib") when the stream teardown path was refactored to use Stream::destroy() instead of a direct delete.

Restore the log line after Stream::destroy() to maintain consistent entry/exit tracing across PAL stream APIs, which aids in debugging stream lifecycle issues.