### PR TITLE
build: remove PAL headers dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,6 @@ AM_CPPFLAGS += -I $(top_srcdir)/plugins/codecs
 AM_CPPFLAGS += -I $(top_srcdir)/
 AM_CPPFLAGS += -I $(top_srcdir)/plugins/vui_interface/api/vui-interface
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -203,4 +203,4 @@ audioadsprpcd_la_CFLAGS = -fPIC
 endif
 
 
-SUBDIRS =  plugins . session stream device plugins/configs
+SUBDIRS =  inc plugins . session stream device plugins/configs

--- a/configure.ac
+++ b/configure.ac
@@ -104,9 +104,6 @@ AC_SUBST([CAPIV2HEADERS_CFLAGS])
 
 if (test "x${with_openwrt}" = "xno"); then
 
-PKG_CHECK_MODULES([PALHEADERS], [pal-headers])
-AC_SUBST([PALHEADERS_CFLAGS])
-
 PKG_CHECK_MODULES([KVH2XML], [kvh2xml])
 AC_SUBST([KVH2XML_CFLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,10 @@ AC_ARG_WITH([streamSoundTrigger],
     [with_streamSoundTrigger=no])
 AM_CONDITIONAL([COMPILE_STREAMSOUNDTRIGGER], [test "x${with_streamSoundTrigger}" = "xyes"])
 
+AC_CONFIG_SUBDIRS([
+        inc
+])
+
 AC_CONFIG_FILES([ Makefile \
 pal.pc \
 stream/Makefile \

--- a/plugins/PluginManager/Makefile.am
+++ b/plugins/PluginManager/Makefile.am
@@ -32,7 +32,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/context_manager/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/vui_interface/api/vui-interface/
 AM_CPPFLAGS += -I $(top_srcdir)/plugins/codecs
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 
 plugin_manager_sources = ${top_srcdir}/plugins/PluginManager/src/PluginManager.cpp
 endif

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/Makefile.am
@@ -20,7 +20,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionUt
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionAlsaCompress/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionAlsaPcm/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionAlsaVoice/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/IoT/default/ConfigSessionUtils/Makefile.am
+++ b/plugins/configs/qcom/IoT/default/ConfigSessionUtils/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/IoT/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -fPIC
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/Makefile.am
@@ -20,7 +20,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessio
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionAlsaCompress/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionAlsaPcm/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionAlsaVoice/inc
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/configs/qcom/mobile/default/ConfigSessionUtils/Makefile.am
+++ b/plugins/configs/qcom/mobile/default/ConfigSessionUtils/Makefile.am
@@ -19,7 +19,6 @@ AM_CPPFLAGS += -I ${top_srcdir}/plugins/codecs/
 AM_CPPFLAGS += -I ${top_srcdir}/plugins/configs/qcom/mobile/default/ConfigSessionUtils/inc
 AM_CPPFLAGS += -fPIC
 AM_CPPFLAGS += @AGM_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
 AM_CPPFLAGS += @AROUTE_CFLAGS@

--- a/plugins/vui_interface/configure.ac
+++ b/plugins/vui_interface/configure.ac
@@ -53,9 +53,6 @@ if (test "x${with_glib}" = "xyes"); then
         AC_SUBST(GLIB_LIBS)
 fi
 
-PKG_CHECK_MODULES([PALHEADERS],[pal-headers])
-AC_SUBST([PALHEADERS_CFLAGS])
-
 PKG_CHECK_MODULES([SPFHEADER],[spf])
 AC_SUBST([SPFHEADER_CFLAGS])
 

--- a/plugins/vui_interface/sva_intf/Makefile.am
+++ b/plugins/vui_interface/sva_intf/Makefile.am
@@ -13,7 +13,6 @@ library_includedir = $(includedir)/sva_interface
 AM_CPPFLAGS += @SPF_CFLAGS@
 AM_CPPFLAGS += @VUIINTERFACEHEADERS_CFLAGS@
 AM_CPPFLAGS += @KVH2XML_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 AM_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\)
 AM_CPPFLAGS += -I $(top_srcdir)/sva_intf/src/
 AM_CPPFLAGS += -I $(top_srcdir)/sva_intf/inc/

--- a/plugins/vui_interface/utils/Makefile.am
+++ b/plugins/vui_interface/utils/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS := -DVUI_USE_SYSLOG @GLIB_CFLAGS@ -include glib.h
 AM_CPPFLAGS += -I $(top_srcdir)/utils/src/
 AM_CPPFLAGS += -I $(top_srcdir)/utils/inc/
 AM_CPPFLAGS += @VUIINTERFACEHEADERS_CFLAGS@
-AM_CPPFLAGS += @PALHEADERS_CFLAGS@
 
 library_include_HEADERS = $(h_sources)
 library_includedir = $(includedir)/vui_interface_utils


### PR DESCRIPTION
Remove PALHEADERS_CFLAGS usage from configure and Makefile.am files across PAL plugins and VUI components.

The headers are built from the same source tree, so requiring a separate pal-headers pkg-config dependency causes configure failures during standalone and Debian package builds.