### PR TITLE
pal: fix playback blocked during concurrent capture and playback

### DIFF
--- a/resource_manager/src/ResourceManager.cpp
+++ b/resource_manager/src/ResourceManager.cpp
@@ -3220,11 +3220,12 @@ int ResourceManager::checkandEnableECForRXStream_l(std::shared_ptr<Device> rx_de
             continue;
         }
         mResourceManagerMutex.unlock();
-        /* Use setECRef_l (lock-free) to avoid deadlock with reader thread.
-         * StreamPCM::read() holds mStreamMutex while blocked on DSP data.
-         * setECRef() would try to acquire the same mutex -> deadlock.
-         * setECRef_l skips the mutex lock and is safe here since
-         * mResourceManagerMutex is managed by the caller. */
+        /* Use setECRef_l (lock-free) to avoid potential deadlock.
+         * The Tx stream may hold mStreamMutex (e.g. during an active read
+         * or any other stream operation). setECRef() acquires the same
+         * mutex and would deadlock. setECRef_l skips the mutex acquisition
+         * and is safe here since mResourceManagerMutex is held by the
+         * caller, preventing concurrent EC setup calls. */
         status = tx_stream->setECRef_l(rx_dev, ec_on);
         mResourceManagerMutex.lock();
         if (status != 0 && ec_on) {

--- a/resource_manager/src/ResourceManager.cpp
+++ b/resource_manager/src/ResourceManager.cpp
@@ -3220,10 +3220,12 @@ int ResourceManager::checkandEnableECForRXStream_l(std::shared_ptr<Device> rx_de
             continue;
         }
         mResourceManagerMutex.unlock();
-        if (isDeviceSwitch && tx_stream->isMutexLockedbyRm())
-            status = tx_stream->setECRef_l(rx_dev, ec_on);
-        else
-            status = tx_stream->setECRef(rx_dev, ec_on);
+        /* Use setECRef_l (lock-free) to avoid deadlock with reader thread.
+         * StreamPCM::read() holds mStreamMutex while blocked on DSP data.
+         * setECRef() would try to acquire the same mutex -> deadlock.
+         * setECRef_l skips the mutex lock and is safe here since
+         * mResourceManagerMutex is managed by the caller. */
+        status = tx_stream->setECRef_l(rx_dev, ec_on);
         mResourceManagerMutex.lock();
         if (status != 0 && ec_on) {
             if (status == -ENODEV) {


### PR DESCRIPTION
When capture is already running and playback starts, the echo
cancellation setup for the new playback stream tries to acquire
a lock that the capture thread is already holding while waiting
for DSP data. This causes the playback startup to block for
13-27 seconds resulting in muted audio at the beginning of
playback.

Fixed by using the lock-free variant of the echo reference
setup call, which is safe here since the resource manager
lock is already held preventing any concurrent access.
This is also consistent with how the same operation is
handled for the transmit stream path.

Tested on: LEMANS EVK (IQ-9075)
